### PR TITLE
Revert "Bump org.flywaydb:flyway-database-postgresql from 11.12.0 to 11.13.1 (#21)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 
 [versions]
 datafaker= "2.5.0"
-flyway="11.13.1"
+flyway="11.12.0"
 hikaricp = "7.0.2"
 jackson-datatype-jsr = "2.20.0"
 kafka="4.1.0"


### PR DESCRIPTION
This reverts commit 556fa604920b0cce675c0ea766d33ab495c2b37c.
