### PR TITLE
Revert "Bump org.flywaydb:flyway-database-postgresql

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 
 [versions]
 datafaker= "2.5.1"
-flyway="11.13.3"
+flyway="11.12.0"
 hikaricp = "7.0.2"
 jackson-datatype-jsr = "2.20.0"
 kafka="4.1.0"


### PR DESCRIPTION
Revert "Bump org.flywaydb:flyway-database-postgresql from 11.12.0 to 11.13.3 (#35)"

This reverts commit 945cbd979649b1721b11188241bb476edf54ef7e.