### PR TITLE
No longer store narmeste_leder_fnr on PUT requests.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
@@ -46,7 +46,6 @@ class LinemanagerRequirementRESTHandler(
                 NlResponseSource.getSourceFrom(principal, linemanager)
             )
             narmesteLederService.updateNlBehov(
-                manager = manager,
                 requirementId = requirementId,
                 behovStatus = BehovStatus.BEHOV_FULFILLED
             )

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
@@ -61,13 +61,11 @@ class NarmestelederService(
             ?: throw LinemanagerRequirementNotFoundException("NarmestelederBehovEntity not found for id: $id")
 
     suspend fun updateNlBehov(
-        manager: Manager,
         requirementId: UUID,
         behovStatus: BehovStatus
     ) {
         val narmestelederBehovEntity = findBehovEntityById(requirementId)
         val updatedBehov = narmestelederBehovEntity.copy(
-            narmestelederFnr = manager.nationalIdentificationNumber,
             behovStatus = behovStatus,
         )
         nlDb.updateNlBehov(updatedBehov)


### PR DESCRIPTION
Only update status and send the new fnr with kafka
