### PR TITLE
Send created behov to dialogporten without waiting for background job

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
@@ -121,6 +121,7 @@ class NarmestelederService(
             val insertedEntity = nlDb.insertNlBehov(entity).also {
                 logger.info("Inserted NarmestelederBehovEntity with id: $it")
             }
+            dialogportenService.sendToDialogporten(insertedEntity)
             return insertedEntity.id
         } else {
             logger.info("Not inserting NarmestelederBehovEntity as there is no active sick leave for employee with narmestelederId ${nlBehov.revokedLinemanagerId} in org ${nlBehov.orgNumber}")


### PR DESCRIPTION
This is a revert commit of the one that previously removed to automatic sending on receiving behov on kafka message
