### PR TITLE
chore: remove unused kafka library to fix vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation(libs.ktor.server.micrometer)
     implementation(libs.micrometer.prometheus)
     implementation(libs.kafka.clients)
-    implementation(libs.kafka.twothirteen) { exclude(group = "log4j") }
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.bundles.kotest)
     testImplementation(libs.mockk)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ database-postgresql = { module = "org.postgresql:postgresql", version.ref = "pos
 datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson-datatype-jsr" }
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
-kafka-twothirteen = { module = "org.apache.kafka:kafka_2.13", version.ref = "kafka" }
 koin-ktor = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }
 koin-logger = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }


### PR DESCRIPTION
org.apache.kafka:kafka_2.13 has some vulnerabilities -> https://github.com/navikt/esyfo-narmesteleder/security/dependabot/5
The library is not used, the Kafka client is enough, that is why we can just remove it.