### PR TITLE
Use limitedParallelism view over Dispatchers.IO for Kafka consumers

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/LeesahNLKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/LeesahNLKafkaConsumer.kt
@@ -3,9 +3,9 @@ package no.nav.syfo.narmesteleder.kafka
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -29,7 +29,7 @@ class LeesahNLKafkaConsumer(
     private val kafkaConsumer: KafkaConsumer<String, String>,
     private val jacksonMapper: ObjectMapper,
     private val handler: NlBehovLeesahHandler,
-    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
 ) : KafkaListener {
     private lateinit var job: Job
     private val processed = mutableMapOf<TopicPartition, Long>()
@@ -37,7 +37,7 @@ class LeesahNLKafkaConsumer(
 
     override fun listen() {
         logger.info("Starting leesah consumer")
-        job = scope.launch(Dispatchers.IO + CoroutineName("leesah-consumer")) {
+        job = CoroutineScope(dispatcher + CoroutineName("leesah-consumer")).launch {
             while (isActive) {
                 try {
                     kafkaConsumer.subscribe(listOf(SYKMELDING_NL_TOPIC))

--- a/src/main/kotlin/no/nav/syfo/plugins/RunningTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/RunningTasks.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.plugins
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStarted
 import io.ktor.server.application.ApplicationStopping
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.application.environment.Environment
 import no.nav.syfo.application.kafka.consumerProperties
@@ -31,6 +32,8 @@ fun Application.configureKafkaConsumers() {
     }
     logger.info("Configuring Kafka consumers")
 
+    val kafkaDispatcher = Dispatchers.IO.limitedParallelism(3)
+
     val leesahConsumer = LeesahNLKafkaConsumer(
         handler = nlLeesahHandler,
         jacksonMapper = jacksonMapper(),
@@ -43,7 +46,7 @@ fun Application.configureKafkaConsumers() {
             StringDeserializer(),
             StringDeserializer(),
         ),
-        scope = this,
+        dispatcher = kafkaDispatcher,
     ).apply {
         commitOnAllErrors = environment.kafka.commitOnAllErrors
     }
@@ -60,7 +63,7 @@ fun Application.configureKafkaConsumers() {
             StringDeserializer(),
             StringDeserializer(),
         ),
-        scope = this
+        dispatcher = kafkaDispatcher,
     )
 
     val persistSendtSykmeldingConsumer = PersistSendtSykmeldingConsumer(
@@ -86,7 +89,7 @@ fun Application.configureKafkaConsumers() {
             StringDeserializer(),
             StringDeserializer(),
         ),
-        scope = this,
+        dispatcher = kafkaDispatcher,
         env = environment.otherProperties
     )
 

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/PersistSendtSykmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/PersistSendtSykmeldingConsumer.kt
@@ -3,9 +3,9 @@ package no.nav.syfo.sykmelding.kafka
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -25,7 +25,7 @@ class PersistSendtSykmeldingConsumer(
     private val handler: SendtSykmeldingHandler,
     private val jacksonMapper: ObjectMapper,
     private val kafkaConsumer: KafkaConsumer<String, String?>,
-    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
     private val env: OtherEnvironmentProperties
 ) : KafkaListener {
     private lateinit var job: Job
@@ -38,7 +38,7 @@ class PersistSendtSykmeldingConsumer(
         }
 
         logger.info("Starting persist $SENDT_SYKMELDING_TOPIC consumer")
-        job = scope.launch(Dispatchers.IO + CoroutineName("persist-sendt-sykmelding-consumer")) {
+        job = CoroutineScope(dispatcher + CoroutineName("persist-sendt-sykmelding-consumer")).launch {
             kafkaConsumer.subscribe(listOf(SENDT_SYKMELDING_TOPIC))
             while (isActive) {
                 try {

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingKafkaConsumer.kt
@@ -2,9 +2,9 @@ package no.nav.syfo.sykmelding.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -24,13 +24,13 @@ class SendtSykmeldingKafkaConsumer(
     private val handler: SendtSykmeldingHandler,
     private val jacksonMapper: ObjectMapper,
     private val kafkaConsumer: KafkaConsumer<String, String>,
-    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
 ) : KafkaListener {
     private lateinit var job: Job
 
     override fun listen() {
         logger.info("Starting $SENDT_SYKMELDING_TOPIC consumer")
-        job = scope.launch(Dispatchers.IO + CoroutineName("sendt-sykmelding-consumer")) {
+        job = CoroutineScope(dispatcher + CoroutineName("sendt-sykmelding-consumer")).launch {
             kafkaConsumer.subscribe(listOf(SENDT_SYKMELDING_TOPIC))
             while (isActive) {
                 try {


### PR DESCRIPTION
We have experienced timeouts on the webserver.

Trying to mitigate this by using a separate view over `Dispatchers.IO` for the long running blocking Kafka-consumers. 