### PR TITLE
Aktiver synlige Dialogporten dialoger for mennesker

### DIFF
--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -127,7 +127,7 @@ spec:
     - name: DIALOGPORTEN_UPDATE_POLLING_DELAY
       value: "10m"
     - name: DIALOGPORTEN_API_ONLY
-      value: "true"
+      value: "false"
     - name: PERSIST_SENDT_SYKMELDING
       value: "true"
     - name: MAINTENANCE_TASK_DELAY


### PR DESCRIPTION
## Beskrivelse
13 April skal dialoger som informerer om sykmeldt behov for nærmeste leder gjøres synlige for
menneskelige brukere, og ikke bare integrasjoner via API

## Endringer
 - Toggle env var DIALOGPORTEN_API_ONLY til false
 
## Issue

Closes #253

## Sjekkliste

- [ /] Koden kompilerer og linter uten feil
- [ /] Endringene er testet (manuelt eller automatisk)
- [ /] Ingen sensitiv data eksponert (tokens, credentials, PII)
