### PR TITLE
Enable maintenance task and set delay to 1 hr

### DIFF
--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -141,10 +141,10 @@ spec:
     - name: PERSIST_SENDT_SYKMELDING
       value: "true"
     - name: MAINTENANCE_TASK_DELAY
-      value: "6h"
+      value: "1h"
     - name: DAYS_AFTER_TOM_TO_EXPIRE_BEHOVS
       value: "16"
     - name: BEHOV_MAINTENANCE_TASK_ENABLED
-      value: "false"
+      value: "true"
   envFrom:
     - secret: altinn-subscription-key


### PR DESCRIPTION
<!-- Managed by esyfo-cli. Do not edit manually. Changes will be overwritten.
     For repo-specific customizations, create your own files without this header. -->
## Beskrivelse

<!-- Hva gjør denne PR-en og hvorfor? -->

Skrur på `BehovMaintenanceTask` for å sette `BEHOV_EXPIRED` i databasen og `expiresAt` i Dialogporten hvor sykmeldingens `tom` er utløpt med > 16 dager. 

Endrer delay til 1 time for å få kjørt jobben i løpet av dagen. Kan endres til et annen verdi senere, jobben trenger ikke å kjøre mer enn en gang per døgn. 

## Issue

Closes #252 

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
