### PR TITLE
Upgrade postgres to 18 in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   db:
-    image: postgres:17.6-alpine3.22
+    image: postgres:18.3-alpine3.23
     ports:
       - "5432:5432"
     restart: always

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -52,7 +52,7 @@ spec:
       runtime: java
   gcp:
     sqlInstances:
-      - type: POSTGRES_17
+      - type: POSTGRES_18
         tier: db-f1-micro
         name: esyfo-narmesteleder-instance
         collation: nb_NO.UTF8

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 import kotlin.time.ExperimentalTime
 import kotlin.use
 
-class PsqlContainer : PostgreSQLContainer<PsqlContainer>("postgres:17-alpine")
+class PsqlContainer : PostgreSQLContainer<PsqlContainer>("postgres:18-alpine")
 
 private val log = LoggerFactory.getLogger(TestDB::class.qualifiedName)
 


### PR DESCRIPTION
<!-- Managed by esyfo-cli. Do not edit manually. Changes will be overwritten.
     For repo-specific customizations, create your own files without this header. -->
## Beskrivelse
Oppgrader til postgresql 18 for å få tilgang på uuid v7 som primary keys
<!-- Hva gjør denne PR-en og hvorfor? -->

## Endringer
- Oppgraderer CloudSql til postgres 18 i dev
- Oppgradere postgres i docker-compose til 18
- Oppgradere postgres i testcontainer til 18

<!-- - `fil/modul`: Hva som ble endret -->

## Issue

<!-- Closes #NUMMER / Relates to #NUMMER -->

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
