### PR TITLE
chore: migrate hovmester auto-merge to consumer-owned verify

### DIFF
--- a/.github/workflows/hovmester-sync.yml
+++ b/.github/workflows/hovmester-sync.yml
@@ -14,6 +14,6 @@ jobs:
     with:
       collections: "hovmester,backend"
       github_project: "navikt/157"
-      automerge_app_id: "2906300"
+      pr_app_id: "2906300"
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -1,0 +1,79 @@
+# Managed by team — do not sync from hovmester.
+name: Verify and merge hovmester sync
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  verify-hovmester-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify file scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EXPECTED_PR_AUTHOR: "teamesyfo-automerge[bot]"
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$HEAD_REF" != "hovmester-sync" ]] || [[ "$HEAD_REPO" != "$REPO" ]]; then
+            echo "Not a hovmester sync PR — skipping"
+            exit 0
+          fi
+
+          if [[ "$PR_AUTHOR" != "$EXPECTED_PR_AUTHOR" ]]; then
+            echo "::error::Unexpected PR author: $PR_AUTHOR"
+            echo "Expected PR author: $EXPECTED_PR_AUTHOR"
+            exit 1
+          fi
+
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[] | .filename, (.previous_filename // empty)')
+
+          if [ -z "$FILES" ]; then
+            echo "::warning::No files found — skipping (possible API issue)"
+            exit 1
+          fi
+
+          echo "Changed files:"
+          echo "$FILES"
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            case "$file" in
+              .github/agents/*|\
+              .github/instructions/*|\
+              .github/skills/*|\
+              .github/ISSUE_TEMPLATE/*|\
+              .github/PULL_REQUEST_TEMPLATE.md|\
+              .github/.hovmester-manifest.json|\
+              .github/.copilot-kitchen-manifest.json)
+                ;;
+              *)
+                echo "::error::File outside sync scope: $file"
+                echo "Only hovmester-managed paths are allowed in sync PRs"
+                exit 1
+                ;;
+            esac
+          done <<< "$FILES"
+
+          echo "✅ All files within hovmester sync scope"
+
+      - name: Approve and enable auto-merge
+        if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'teamesyfo-automerge[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --approve --body "Auto-approved: file scope verified ✅"
+          gh pr merge "$PR_NUMBER" --auto --squash

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -18,7 +18,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.head_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -18,6 +18,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.head_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -74,6 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr review "$PR_NUMBER" --approve --body "Auto-approved: file scope verified ✅"
-          gh pr merge "$PR_NUMBER" --auto --squash
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Auto-approved: file scope verified ✅"
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -5,14 +5,14 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   verify-hovmester-sync:
+    if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Verify file scope
         env:
@@ -41,7 +41,7 @@ jobs:
             --paginate --jq '.[] | .filename, (.previous_filename // empty)')
 
           if [ -z "$FILES" ]; then
-            echo "::warning::No files found — skipping (possible API issue)"
+            echo "::error::No files found from pull request files API; failing closed"
             exit 1
           fi
 

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -4,10 +4,11 @@ name: Verify and merge hovmester sync
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 jobs:
   verify-hovmester-sync:
-    if: github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'merge_group' || (github.head_ref == 'hovmester-sync' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
+            echo "✅ Merge queue — verification already completed on pull_request_target"
+            exit 0
+          fi
+
           if [[ "$HEAD_REF" != "hovmester-sync" ]] || [[ "$HEAD_REPO" != "$REPO" ]]; then
             echo "Not a hovmester sync PR — skipping"
             exit 0


### PR DESCRIPTION
## Beskrivelse

Hovmester-sync har fjernet innebygd auto-approve/merge. Ansvaret flyttes til en consumer-eid verify-workflow (`hovmester-verify.yml`).

### Endringer

1. **`hovmester-sync.yml`**: Rename `automerge_app_id` → `pr_app_id`
2. **`hovmester-verify.yml`** (ny): Verifiserer filscope + auto-approver + enabler auto-merge

### Manuelle steg etter merge

- [x] Slå på **Allow auto-merge** i repo settings
- [x] Slå på **Allow squash merging** i repo settings
- [x] Slå på **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests**
- [x] Sett `verify-hovmester-sync` som **required status check** i branch protection (gjør dette *etter* merge)

Se [hovmester README — Auto-merge](https://github.com/navikt/hovmester#auto-merge-valgfritt).