### PR TITLE
refactor(lifecycle): migrate scheduled tasks to Ktor leader events

### DIFF
--- a/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/SendDialogTask.kt
+++ b/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/SendDialogTask.kt
@@ -1,31 +1,16 @@
 package no.nav.syfo.altinn.dialogporten.task
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import no.nav.syfo.altinn.dialogporten.service.DialogportenService
-import no.nav.syfo.util.logger
+import no.nav.syfo.application.task.ScheduledLeaderTask
 import kotlin.time.Duration.Companion.minutes
 
 class SendDialogTask(
-    private val dialogportenService: DialogportenService
+    private val dialogportenService: DialogportenService,
+) : ScheduledLeaderTask(
+    name = "SendDialogTask",
+    interval = 5.minutes,
 ) {
-    private val logger = logger()
-
-    suspend fun runTask() = coroutineScope {
-        try {
-            while (isActive) {
-                try {
-                    logger.info("Starting task for sending documents to dialogporten")
-                    dialogportenService.sendDocumentsToDialogporten()
-                } catch (ex: Exception) {
-                    logger.error("Could not send dialogs to dialogporten", ex)
-                }
-                delay(5.minutes)
-            }
-        } catch (ex: CancellationException) {
-            logger.info("Cancelled SendDialogTask", ex)
-        }
+    override suspend fun execute() {
+        dialogportenService.sendDocumentsToDialogporten()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/SendDialogTask.kt
+++ b/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/SendDialogTask.kt
@@ -5,11 +5,10 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import no.nav.syfo.altinn.dialogporten.service.DialogportenService
-import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.util.logger
+import kotlin.time.Duration.Companion.minutes
 
 class SendDialogTask(
-    private val leaderElection: LeaderElection,
     private val dialogportenService: DialogportenService
 ) {
     private val logger = logger()
@@ -17,16 +16,13 @@ class SendDialogTask(
     suspend fun runTask() = coroutineScope {
         try {
             while (isActive) {
-                if (leaderElection.isLeader()) {
-                    try {
-                        logger.info("Starting task for sending documents to dialogporten")
-                        dialogportenService.sendDocumentsToDialogporten()
-                    } catch (ex: Exception) {
-                        logger.error("Could not send dialogs to dialogporten", ex)
-                    }
+                try {
+                    logger.info("Starting task for sending documents to dialogporten")
+                    dialogportenService.sendDocumentsToDialogporten()
+                } catch (ex: Exception) {
+                    logger.error("Could not send dialogs to dialogporten", ex)
                 }
-                // delay for  5 minutes before checking again
-                delay(5 * 60 * 1000)
+                delay(5.minutes)
             }
         } catch (ex: CancellationException) {
             logger.info("Cancelled SendDialogTask", ex)

--- a/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/UpdateDialogTask.kt
+++ b/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/UpdateDialogTask.kt
@@ -5,12 +5,10 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import no.nav.syfo.altinn.dialogporten.service.DialogportenService
-import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.util.logger
 import kotlin.time.Duration
 
 class UpdateDialogTask(
-    private val leaderElection: LeaderElection,
     private val dialogportenService: DialogportenService,
     private val pollingInterval: Duration
 ) {
@@ -19,14 +17,12 @@ class UpdateDialogTask(
     suspend fun runTask() = coroutineScope {
         try {
             while (isActive) {
-                if (leaderElection.isLeader()) {
-                    try {
-                        logger.info("Starting task for updating dialog statuses")
-                        dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten()
-                        dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten()
-                    } catch (ex: Exception) {
-                        logger.error("Could not update dialogs in dialogporten", ex)
-                    }
+                try {
+                    logger.info("Starting task for updating dialog statuses")
+                    dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten()
+                    dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten()
+                } catch (ex: Exception) {
+                    logger.error("Could not update dialogs in dialogporten", ex)
                 }
                 delay(pollingInterval)
             }

--- a/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/UpdateDialogTask.kt
+++ b/src/main/kotlin/no/nav/syfo/altinn/dialogporten/task/UpdateDialogTask.kt
@@ -1,33 +1,18 @@
 package no.nav.syfo.altinn.dialogporten.task
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import no.nav.syfo.altinn.dialogporten.service.DialogportenService
-import no.nav.syfo.util.logger
+import no.nav.syfo.application.task.ScheduledLeaderTask
 import kotlin.time.Duration
 
 class UpdateDialogTask(
     private val dialogportenService: DialogportenService,
-    private val pollingInterval: Duration
+    pollingInterval: Duration,
+) : ScheduledLeaderTask(
+    name = "UpdateDialogTask",
+    interval = pollingInterval,
 ) {
-    private val logger = logger()
-
-    suspend fun runTask() = coroutineScope {
-        try {
-            while (isActive) {
-                try {
-                    logger.info("Starting task for updating dialog statuses")
-                    dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten()
-                    dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten()
-                } catch (ex: Exception) {
-                    logger.error("Could not update dialogs in dialogporten", ex)
-                }
-                delay(pollingInterval)
-            }
-        } catch (ex: CancellationException) {
-            logger.info("Cancelled UpdateDialogTask", ex)
-        }
+    override suspend fun execute() {
+        dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten()
+        dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/application/task/ScheduledLeaderTask.kt
+++ b/src/main/kotlin/no/nav/syfo/application/task/ScheduledLeaderTask.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.application.task
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import no.nav.syfo.util.logger
+import kotlin.time.Duration
+
+abstract class ScheduledLeaderTask(
+    name: String,
+    private val interval: Duration,
+) {
+    private val logger = logger(name)
+    private val taskName = name
+
+    abstract suspend fun execute()
+
+    suspend fun runTask() = coroutineScope {
+        try {
+            while (isActive) {
+                try {
+                    execute()
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    logger.error("Error while executing $taskName", ex)
+                }
+                delay(interval)
+            }
+        } catch (_: CancellationException) {
+            logger.info("$taskName stopped gracefully")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTask.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTask.kt
@@ -5,14 +5,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import no.nav.syfo.application.environment.OtherEnvironmentProperties
-import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.narmesteleder.service.NarmestelederService
 import no.nav.syfo.util.logger
 import kotlin.time.Duration
 
 class BehovMaintenanceTask(
     private val narmestelederService: NarmestelederService,
-    private val leaderElection: LeaderElection,
     private val env: OtherEnvironmentProperties
 ) {
     private val logger = logger()
@@ -20,15 +18,13 @@ class BehovMaintenanceTask(
     suspend fun runTask() = coroutineScope {
         try {
             while (isActive) {
-                if (leaderElection.isLeader()) {
-                    try {
-                        logger.info("Starting task for behov maintenance")
-                        narmestelederService.updateStatusOnExpiredBehovs(
-                            env.daysAfterTomToExpireBehovs
-                        )
-                    } catch (ex: Exception) {
-                        logger.error("Something went wrong", ex)
-                    }
+                try {
+                    logger.info("Starting task for behov maintenance")
+                    narmestelederService.updateStatusOnExpiredBehovs(
+                        env.daysAfterTomToExpireBehovs
+                    )
+                } catch (ex: Exception) {
+                    logger.error("Something went wrong", ex)
                 }
                 delay(Duration.parse(env.maintenanceTaskDelay))
             }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTask.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTask.kt
@@ -1,35 +1,18 @@
 package no.nav.syfo.narmesteleder.task
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import no.nav.syfo.application.environment.OtherEnvironmentProperties
+import no.nav.syfo.application.task.ScheduledLeaderTask
 import no.nav.syfo.narmesteleder.service.NarmestelederService
-import no.nav.syfo.util.logger
 import kotlin.time.Duration
 
 class BehovMaintenanceTask(
     private val narmestelederService: NarmestelederService,
-    private val env: OtherEnvironmentProperties
+    private val env: OtherEnvironmentProperties,
+) : ScheduledLeaderTask(
+    name = "BehovMaintenanceTask",
+    interval = Duration.parse(env.maintenanceTaskDelay),
 ) {
-    private val logger = logger()
-
-    suspend fun runTask() = coroutineScope {
-        try {
-            while (isActive) {
-                try {
-                    logger.info("Starting task for behov maintenance")
-                    narmestelederService.updateStatusOnExpiredBehovs(
-                        env.daysAfterTomToExpireBehovs
-                    )
-                } catch (ex: Exception) {
-                    logger.error("Something went wrong", ex)
-                }
-                delay(Duration.parse(env.maintenanceTaskDelay))
-            }
-        } catch (ex: CancellationException) {
-            logger.info("Cancelled BehovMaintenanceTask", ex)
-        }
+    override suspend fun execute() {
+        narmestelederService.updateStatusOnExpiredBehovs(env.daysAfterTomToExpireBehovs)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
@@ -1,13 +1,14 @@
 package no.nav.syfo.plugins
 
 import io.ktor.server.application.Application
-import io.ktor.server.application.ApplicationStarted
 import io.ktor.server.application.ApplicationStopping
-import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import no.nav.syfo.altinn.dialogporten.task.SendDialogTask
 import no.nav.syfo.altinn.dialogporten.task.UpdateDialogTask
 import no.nav.syfo.application.environment.Environment
+import no.nav.syfo.application.events.LeaderChange
+import no.nav.syfo.application.events.LeaderChangeEvent
 import no.nav.syfo.narmesteleder.task.BehovMaintenanceTask
 import no.nav.syfo.util.logger
 import org.koin.ktor.ext.inject
@@ -23,38 +24,39 @@ fun Application.configureBackgroundTasks() {
     logger.info("Integration with Dialogporten is enabled. Configuring background tasks")
 
     val sendDialogTask by inject<SendDialogTask>()
-    val updateDialogTast by inject<UpdateDialogTask>()
+    val updateDialogTask by inject<UpdateDialogTask>()
     val behovMaintenanceTask by inject<BehovMaintenanceTask>()
 
-    val behovMaintenanceTaskJob = launch(start = CoroutineStart.LAZY) { behovMaintenanceTask.runTask() }
-    val sendDialogTaskJob = launch(start = CoroutineStart.LAZY) { sendDialogTask.runTask() }
-    val updateDialogTaskJob = launch(start = CoroutineStart.LAZY) { updateDialogTast.runTask() }
+    var sendDialogTaskJob: Job? = null
+    var updateDialogTaskJob: Job? = null
+    var behovMaintenanceTaskJob: Job? = null
 
-    if (environment.otherProperties.maintenanceTaskEnabled) {
-        monitor.subscribe(ApplicationStarted) {
-            behovMaintenanceTaskJob.start()
+    monitor.subscribe(LeaderChangeEvent) { event ->
+        when (event) {
+            is LeaderChange.Promoted -> {
+                logger.info("Promoted to leader — starting background tasks")
+                sendDialogTaskJob = launch { sendDialogTask.runTask() }
+                updateDialogTaskJob = launch { updateDialogTask.runTask() }
+
+                if (environment.otherProperties.maintenanceTaskEnabled) {
+                    behovMaintenanceTaskJob = launch { behovMaintenanceTask.runTask() }
+                }
+            }
+
+            is LeaderChange.Demoted -> {
+                logger.info("Demoted from leader — cancelling background tasks")
+                sendDialogTaskJob?.cancel()
+                updateDialogTaskJob?.cancel()
+                behovMaintenanceTaskJob?.cancel()
+            }
+
+            is LeaderChange.Unaffected -> {}
         }
-        monitor.subscribe(ApplicationStopping) {
-            behovMaintenanceTaskJob.cancel()
-        }
-    } else {
-        logger.info("Behov maintenance task is not enabled. Skipping task")
     }
 
-    if (environment.otherProperties.isDialogportenBackgroundTaskEnabled) {
-        logger.info("Integration with Dialogporten is enabled. Configuring background tasks")
-        monitor.subscribe(ApplicationStarted) {
-            sendDialogTaskJob.start()
-            updateDialogTaskJob.start()
-        }
-        monitor.subscribe(ApplicationStopping) {
-            if (!environment.otherProperties.isDialogportenBackgroundTaskEnabled) {
-                return@subscribe
-            }
-            sendDialogTaskJob.cancel()
-            updateDialogTaskJob.cancel()
-        }
-    } else {
-        logger.info("Integration with Dialogporten is not enabled. Skipping background tasks")
+    monitor.subscribe(ApplicationStopping) {
+        sendDialogTaskJob?.cancel()
+        updateDialogTaskJob?.cancel()
+        behovMaintenanceTaskJob?.cancel()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -28,7 +28,6 @@ import no.nav.syfo.application.environment.isLocalEnv
 import no.nav.syfo.application.kafka.JacksonKafkaSerializer
 import no.nav.syfo.application.kafka.producerProperties
 import no.nav.syfo.application.leaderelection.LeaderChangeSSEListener
-import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.application.valkey.EregCache
 import no.nav.syfo.application.valkey.PdlCache
 import no.nav.syfo.application.valkey.ValkeyCache
@@ -247,7 +246,6 @@ private fun servicesModule() = module {
     single { PdlService(get(), get()) }
 
     single { AltinnTilgangerService(get()) }
-    single { LeaderElection(get(), env().otherProperties.electorPath) }
     single {
         LeaderChangeSSEListener(httpClientSSE(), env().otherProperties.electorSSEUrl)
     }
@@ -290,14 +288,13 @@ private fun tasksModule() = module {
     single {
         BehovMaintenanceTask(
             narmestelederService = get(),
-            leaderElection = get(),
             env = env().otherProperties
         )
     }
-    single { SendDialogTask(get(), get()) }
+    single { SendDialogTask(get()) }
     single {
         val pollingInterval = Duration.parse(env().otherProperties.updateDialogportenTaskProperties.pollingDelay)
-        UpdateDialogTask(get(), get(), pollingInterval)
+        UpdateDialogTask(get(), pollingInterval)
     }
 }
 

--- a/src/test/kotlin/no/nav/syfo/application/task/ScheduledLeaderTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/task/ScheduledLeaderTaskTest.kt
@@ -1,0 +1,133 @@
+package no.nav.syfo.application.task
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.ints.shouldBeExactly
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScheduledLeaderTaskTest :
+    DescribeSpec(
+        {
+            describe("ScheduledLeaderTask") {
+                context("runTask") {
+                    it("should call execute on each iteration") {
+                        runTest {
+                            var executeCount = 0
+                            val task = TestScheduledLeaderTask(
+                                interval = 100.milliseconds,
+                            ) {
+                                executeCount++
+                            }
+
+                            val job = launch {
+                                task.runTask()
+                            }
+
+                            runCurrent()
+                            executeCount.shouldBeExactly(1)
+
+                            advanceTimeBy(100)
+                            runCurrent()
+                            executeCount.shouldBeExactly(2)
+
+                            advanceTimeBy(100)
+                            runCurrent()
+                            executeCount.shouldBeExactly(3)
+
+                            job.cancelAndJoin()
+                        }
+                    }
+
+                    it("should continue running after exception in execute") {
+                        runTest {
+                            var executeCount = 0
+                            val task = TestScheduledLeaderTask(
+                                interval = 100.milliseconds,
+                            ) {
+                                executeCount++
+                                if (executeCount == 1) {
+                                    throw RuntimeException("Test exception")
+                                }
+                            }
+
+                            val job = launch {
+                                task.runTask()
+                            }
+
+                            runCurrent()
+                            executeCount.shouldBeExactly(1)
+
+                            advanceTimeBy(100)
+                            runCurrent()
+                            executeCount.shouldBeExactly(2)
+
+                            job.cancelAndJoin()
+                        }
+                    }
+
+                    it("should handle cancellation gracefully") {
+                        runTest {
+                            val task = TestScheduledLeaderTask(
+                                interval = 100.milliseconds,
+                            ) {}
+
+                            val job = launch {
+                                task.runTask()
+                            }
+
+                            runCurrent()
+                            job.cancelAndJoin()
+
+                            job.isActive.shouldBeFalse()
+                            job.isCompleted.shouldBeTrue()
+                        }
+                    }
+
+                    it("should stop when cancelled") {
+                        runTest {
+                            var executeCount = 0
+                            val task = TestScheduledLeaderTask(
+                                interval = 100.milliseconds,
+                            ) {
+                                executeCount++
+                            }
+
+                            val job = launch {
+                                task.runTask()
+                            }
+
+                            runCurrent()
+                            executeCount.shouldBeExactly(1)
+
+                            job.cancelAndJoin()
+                            advanceTimeBy(1_000)
+                            runCurrent()
+
+                            executeCount.shouldBeExactly(1)
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+private class TestScheduledLeaderTask(
+    interval: Duration,
+    private val onExecute: suspend () -> Unit,
+) : ScheduledLeaderTask(
+    name = "TestScheduledLeaderTask",
+    interval = interval,
+) {
+    override suspend fun execute() {
+        onExecute()
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/dialogporten/task/SendDialogTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogporten/task/SendDialogTaskTest.kt
@@ -17,58 +17,24 @@ class SendDialogTaskTest :
     DescribeSpec({
         val dialogportenService = mockk<DialogportenService>()
 
-        lateinit var sendDialogTask: SendDialogTask
-
         beforeTest {
             clearAllMocks()
-            sendDialogTask = SendDialogTask(dialogportenService = dialogportenService)
         }
 
-        describe("runTask") {
+        describe("execute") {
             it("should call sendDocumentsToDialogporten") {
                 coEvery { dialogportenService.sendDocumentsToDialogporten() } just Runs
 
+                val task = SendDialogTask(dialogportenService = dialogportenService)
+
                 val job = launch {
-                    sendDialogTask.runTask()
+                    task.runTask()
                 }
 
                 delay(100.milliseconds)
                 job.cancel()
 
                 coVerify(atLeast = 1) { dialogportenService.sendDocumentsToDialogporten() }
-            }
-
-            it("should continue running even if sendDocumentsToDialogporten throws exception") {
-                var callCount = 0
-                coEvery { dialogportenService.sendDocumentsToDialogporten() } answers {
-                    callCount++
-                    if (callCount == 1) {
-                        throw RuntimeException("Test exception")
-                    }
-                }
-
-                val job = launch {
-                    sendDialogTask.runTask()
-                }
-
-                // SendDialogTask has a 5-minute delay, so we can't wait for a second iteration
-                // in a unit test. We verify the first call happened and the task survived the exception.
-                delay(100.milliseconds)
-                job.cancel()
-
-                coVerify(atLeast = 1) { dialogportenService.sendDocumentsToDialogporten() }
-            }
-
-            it("should gracefully handle cancellation") {
-                coEvery { dialogportenService.sendDocumentsToDialogporten() } just Runs
-
-                val job = launch {
-                    sendDialogTask.runTask()
-                }
-
-                delay(50.milliseconds)
-
-                job.cancel()
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/dialogporten/task/SendDialogTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogporten/task/SendDialogTaskTest.kt
@@ -1,0 +1,74 @@
+package no.nav.syfo.dialogporten.task
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import no.nav.syfo.altinn.dialogporten.service.DialogportenService
+import no.nav.syfo.altinn.dialogporten.task.SendDialogTask
+import kotlin.time.Duration.Companion.milliseconds
+
+class SendDialogTaskTest :
+    DescribeSpec({
+        val dialogportenService = mockk<DialogportenService>()
+
+        lateinit var sendDialogTask: SendDialogTask
+
+        beforeTest {
+            clearAllMocks()
+            sendDialogTask = SendDialogTask(dialogportenService = dialogportenService)
+        }
+
+        describe("runTask") {
+            it("should call sendDocumentsToDialogporten") {
+                coEvery { dialogportenService.sendDocumentsToDialogporten() } just Runs
+
+                val job = launch {
+                    sendDialogTask.runTask()
+                }
+
+                delay(100.milliseconds)
+                job.cancel()
+
+                coVerify(atLeast = 1) { dialogportenService.sendDocumentsToDialogporten() }
+            }
+
+            it("should continue running even if sendDocumentsToDialogporten throws exception") {
+                var callCount = 0
+                coEvery { dialogportenService.sendDocumentsToDialogporten() } answers {
+                    callCount++
+                    if (callCount == 1) {
+                        throw RuntimeException("Test exception")
+                    }
+                }
+
+                val job = launch {
+                    sendDialogTask.runTask()
+                }
+
+                // SendDialogTask has a 5-minute delay, so we can't wait for a second iteration
+                // in a unit test. We verify the first call happened and the task survived the exception.
+                delay(100.milliseconds)
+                job.cancel()
+
+                coVerify(atLeast = 1) { dialogportenService.sendDocumentsToDialogporten() }
+            }
+
+            it("should gracefully handle cancellation") {
+                coEvery { dialogportenService.sendDocumentsToDialogporten() } just Runs
+
+                val job = launch {
+                    sendDialogTask.runTask()
+                }
+
+                delay(50.milliseconds)
+
+                job.cancel()
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/dialogporten/task/UpdateDialogTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogporten/task/UpdateDialogTaskTest.kt
@@ -11,13 +11,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import no.nav.syfo.altinn.dialogporten.service.DialogportenService
 import no.nav.syfo.altinn.dialogporten.task.UpdateDialogTask
-import no.nav.syfo.application.leaderelection.LeaderElection
 import kotlin.time.Duration.Companion.milliseconds
 
 class UpdateDialogTaskTest :
     DescribeSpec({
         val dialogportenService = mockk<DialogportenService>()
-        val leaderElection = mockk<LeaderElection>()
         val pollingInterval = 100.milliseconds
 
         lateinit var updateDialogTask: UpdateDialogTask
@@ -26,136 +24,80 @@ class UpdateDialogTaskTest :
             clearAllMocks()
             updateDialogTask =
                 UpdateDialogTask(
-                    leaderElection = leaderElection,
                     dialogportenService = dialogportenService,
                     pollingInterval = pollingInterval
                 )
         }
 
         describe("runTask") {
-            context("when pod is leader") {
-                it("should call both setAllFulfilledBehovsAsCompletedInDialogporten and setAllExpiredBehovsAsExpiredAndCompletedInDialogporten") {
-                    // Arrange
-                    coEvery { leaderElection.isLeader() } returns true
-                    coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
-                    coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
+            it("should call both setAllFulfilledBehovsAsCompletedInDialogporten and setAllExpiredBehovsAsExpiredAndCompletedInDialogporten") {
+                coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
+                coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
 
-                    // Act
-                    val job = launch {
-                        updateDialogTask.runTask()
-                    }
-
-                    // Give it time to execute at least once
-                    delay(150.milliseconds)
-                    job.cancel()
-
-                    // Assert
-                    coVerify(atLeast = 1) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                    coVerify(atLeast = 1) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
+                val job = launch {
+                    updateDialogTask.runTask()
                 }
 
-                it("should continue running even if setAllFulfilledBehovsAsCompletedInDialogporten throws exception") {
-                    // Arrange
-                    var callCount = 0
-                    coEvery { leaderElection.isLeader() } returns true
-                    coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } answers {
-                        callCount++
-                        if (callCount == 1) {
-                            throw RuntimeException("Test exception")
-                        }
-                    }
-                    coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
+                delay(150.milliseconds)
+                job.cancel()
 
-                    // Act
-                    val job = launch {
-                        updateDialogTask.runTask()
-                    }
-
-                    // Give it time to execute multiple times
-                    delay(250.milliseconds)
-                    job.cancel()
-
-                    // Assert - should have been called at least twice (once failed, once succeeded)
-                    coVerify(atLeast = 2) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                    coVerify(atLeast = 1) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
-                }
-
-                it("should continue running even if setAllExpiredBehovsAsExpiredAndCompletedInDialogporten throws exception") {
-                    // Arrange
-                    var callCount = 0
-                    coEvery { leaderElection.isLeader() } returns true
-                    coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
-                    coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } answers {
-                        callCount++
-                        if (callCount == 1) {
-                            throw RuntimeException("Test exception")
-                        }
-                    }
-
-                    // Act
-                    val job = launch {
-                        updateDialogTask.runTask()
-                    }
-
-                    // Give it time to execute multiple times
-                    delay(250.milliseconds)
-                    job.cancel()
-
-                    // Assert - should have been called at least twice (once failed, once succeeded)
-                    coVerify(atLeast = 1) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                    coVerify(atLeast = 2) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
-                }
+                coVerify(atLeast = 1) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
+                coVerify(atLeast = 1) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
             }
 
-            context("when pod is not leader") {
-                it("should not call dialogporten service methods") {
-                    // Arrange
-                    coEvery { leaderElection.isLeader() } returns false
-
-                    // Act
-                    val job = launch {
-                        updateDialogTask.runTask()
+            it("should continue running even if setAllFulfilledBehovsAsCompletedInDialogporten throws exception") {
+                var callCount = 0
+                coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } answers {
+                    callCount++
+                    if (callCount == 1) {
+                        throw RuntimeException("Test exception")
                     }
-
-                    // Give it time to execute at least once
-                    delay(150.milliseconds)
-                    job.cancel()
-
-                    // Assert
-                    coVerify(exactly = 0) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                    coVerify(exactly = 0) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
                 }
+                coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
+
+                val job = launch {
+                    updateDialogTask.runTask()
+                }
+
+                delay(250.milliseconds)
+                job.cancel()
+
+                coVerify(atLeast = 2) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
+                coVerify(atLeast = 1) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
             }
 
-            context("when leadership changes") {
-                it("should start calling service methods when becoming leader") {
-                    // Arrange
-                    var isLeader = false
-                    coEvery { leaderElection.isLeader() } answers { isLeader }
-                    coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
-                    coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
-
-                    // Act
-                    val job = launch {
-                        updateDialogTask.runTask()
+            it("should continue running even if setAllExpiredBehovsAsExpiredAndCompletedInDialogporten throws exception") {
+                var callCount = 0
+                coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
+                coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } answers {
+                    callCount++
+                    if (callCount == 1) {
+                        throw RuntimeException("Test exception")
                     }
-
-                    // Wait while not leader
-                    delay(150.milliseconds)
-
-                    // Verify no calls while not leader
-                    coVerify(exactly = 0) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                    coVerify(exactly = 0) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
-
-                    // Become leader
-                    isLeader = true
-                    delay(150.milliseconds)
-                    job.cancel()
-
-                    // Assert - should have been called after becoming leader
-                    coVerify(atLeast = 1) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                    coVerify(atLeast = 1) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
                 }
+
+                val job = launch {
+                    updateDialogTask.runTask()
+                }
+
+                delay(250.milliseconds)
+                job.cancel()
+
+                coVerify(atLeast = 1) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
+                coVerify(atLeast = 2) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
+            }
+
+            it("should gracefully handle cancellation") {
+                coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
+                coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
+
+                val job = launch {
+                    updateDialogTask.runTask()
+                }
+
+                delay(50.milliseconds)
+
+                job.cancel()
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/dialogporten/task/UpdateDialogTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogporten/task/UpdateDialogTaskTest.kt
@@ -25,11 +25,11 @@ class UpdateDialogTaskTest :
             updateDialogTask =
                 UpdateDialogTask(
                     dialogportenService = dialogportenService,
-                    pollingInterval = pollingInterval
+                    pollingInterval = pollingInterval,
                 )
         }
 
-        describe("runTask") {
+        describe("execute") {
             it("should call both setAllFulfilledBehovsAsCompletedInDialogporten and setAllExpiredBehovsAsExpiredAndCompletedInDialogporten") {
                 coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
                 coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
@@ -43,61 +43,6 @@ class UpdateDialogTaskTest :
 
                 coVerify(atLeast = 1) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
                 coVerify(atLeast = 1) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
-            }
-
-            it("should continue running even if setAllFulfilledBehovsAsCompletedInDialogporten throws exception") {
-                var callCount = 0
-                coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } answers {
-                    callCount++
-                    if (callCount == 1) {
-                        throw RuntimeException("Test exception")
-                    }
-                }
-                coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
-
-                val job = launch {
-                    updateDialogTask.runTask()
-                }
-
-                delay(250.milliseconds)
-                job.cancel()
-
-                coVerify(atLeast = 2) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                coVerify(atLeast = 1) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
-            }
-
-            it("should continue running even if setAllExpiredBehovsAsExpiredAndCompletedInDialogporten throws exception") {
-                var callCount = 0
-                coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
-                coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } answers {
-                    callCount++
-                    if (callCount == 1) {
-                        throw RuntimeException("Test exception")
-                    }
-                }
-
-                val job = launch {
-                    updateDialogTask.runTask()
-                }
-
-                delay(250.milliseconds)
-                job.cancel()
-
-                coVerify(atLeast = 1) { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() }
-                coVerify(atLeast = 2) { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() }
-            }
-
-            it("should gracefully handle cancellation") {
-                coEvery { dialogportenService.setAllFulfilledBehovsAsCompletedInDialogporten() } just Runs
-                coEvery { dialogportenService.setAllExpiredBehovsAsExpiredAndCompletedInDialogporten() } just Runs
-
-                val job = launch {
-                    updateDialogTask.runTask()
-                }
-
-                delay(50.milliseconds)
-
-                job.cancel()
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTaskTest.kt
@@ -12,14 +12,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import no.nav.syfo.application.environment.OtherEnvironmentProperties
 import no.nav.syfo.application.environment.UpdateDialogportenTaskProperties
-import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.narmesteleder.service.NarmestelederService
 import kotlin.time.Duration.Companion.milliseconds
 
 class BehovMaintenanceTaskTest :
     DescribeSpec({
         val narmestelederService = mockk<NarmestelederService>()
-        val leaderElection = mockk<LeaderElection>()
 
         val env = OtherEnvironmentProperties(
             electorPath = "elector",
@@ -38,7 +36,6 @@ class BehovMaintenanceTaskTest :
 
         fun createTask() = BehovMaintenanceTask(
             narmestelederService = narmestelederService,
-            leaderElection = leaderElection,
             env = env
         )
 
@@ -48,24 +45,18 @@ class BehovMaintenanceTaskTest :
 
         describe("BehovMaintenanceTask") {
             context("runTask") {
-                it("should call updateStatusOnExpiredBehovs when leader") {
-                    // Arrange
-                    coEvery { leaderElection.isLeader() } returns true
+                it("should call updateStatusOnExpiredBehovs") {
                     coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } just Runs
 
                     val task = createTask()
 
-                    // Act
                     val job = launch {
                         task.runTask()
                     }
 
-                    // Wait for task to run at least once
                     delay(100.milliseconds)
                     job.cancelAndJoin()
 
-                    // Assert
-                    coVerify(atLeast = 1) { leaderElection.isLeader() }
                     coVerify(atLeast = 1) {
                         narmestelederService.updateStatusOnExpiredBehovs(
                             env.daysAfterTomToExpireBehovs
@@ -73,30 +64,8 @@ class BehovMaintenanceTaskTest :
                     }
                 }
 
-                it("should not call updateStatusOnExpiredBehovs when not leader") {
-                    // Arrange
-                    coEvery { leaderElection.isLeader() } returns false
-
-                    val task = createTask()
-
-                    // Act
-                    val job = launch {
-                        task.runTask()
-                    }
-
-                    // Wait for task to run at least once
-                    delay(100.milliseconds)
-                    job.cancelAndJoin()
-
-                    // Assert
-                    coVerify(atLeast = 1) { leaderElection.isLeader() }
-                    coVerify(exactly = 0) { narmestelederService.updateStatusOnExpiredBehovs(any()) }
-                }
-
                 it("should continue running after exception in updateStatusOnExpiredBehovs") {
-                    // Arrange
                     var callCount = 0
-                    coEvery { leaderElection.isLeader() } returns true
                     coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } answers {
                         callCount++
                         if (callCount == 1) {
@@ -106,33 +75,26 @@ class BehovMaintenanceTaskTest :
 
                     val task = createTask()
 
-                    // Act
                     val job = launch {
                         task.runTask()
                     }
 
-                    // Wait for task to run multiple times
                     delay(150.milliseconds)
                     job.cancelAndJoin()
 
-                    // Assert - should have been called at least twice (once with exception, once without)
                     coVerify(atLeast = 2) { narmestelederService.updateStatusOnExpiredBehovs(any()) }
                 }
 
                 it("should use correct daysAfterTomToExpireBehovs value") {
-                    // Arrange
                     val customDays = 14L
                     val customEnv = env.copy(daysAfterTomToExpireBehovs = customDays)
                     val task = BehovMaintenanceTask(
                         narmestelederService = narmestelederService,
-                        leaderElection = leaderElection,
                         env = customEnv
                     )
 
-                    coEvery { leaderElection.isLeader() } returns true
                     coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } just Runs
 
-                    // Act
                     val job = launch {
                         task.runTask()
                     }
@@ -140,27 +102,22 @@ class BehovMaintenanceTaskTest :
                     delay(100.milliseconds)
                     job.cancelAndJoin()
 
-                    // Assert
                     coVerify(atLeast = 1) {
                         narmestelederService.updateStatusOnExpiredBehovs(eq(customDays))
                     }
                 }
 
                 it("should gracefully handle cancellation") {
-                    // Arrange
-                    coEvery { leaderElection.isLeader() } returns true
                     coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } just Runs
 
                     val task = createTask()
 
-                    // Act
                     val job = launch {
                         task.runTask()
                     }
 
                     delay(50.milliseconds)
 
-                    // Assert - should not throw when cancelled
                     job.cancelAndJoin()
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTaskTest.kt
@@ -36,7 +36,7 @@ class BehovMaintenanceTaskTest :
 
         fun createTask() = BehovMaintenanceTask(
             narmestelederService = narmestelederService,
-            env = env
+            env = env,
         )
 
         beforeTest {
@@ -44,7 +44,7 @@ class BehovMaintenanceTaskTest :
         }
 
         describe("BehovMaintenanceTask") {
-            context("runTask") {
+            context("execute") {
                 it("should call updateStatusOnExpiredBehovs") {
                     coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } just Runs
 
@@ -59,30 +59,9 @@ class BehovMaintenanceTaskTest :
 
                     coVerify(atLeast = 1) {
                         narmestelederService.updateStatusOnExpiredBehovs(
-                            env.daysAfterTomToExpireBehovs
+                            env.daysAfterTomToExpireBehovs,
                         )
                     }
-                }
-
-                it("should continue running after exception in updateStatusOnExpiredBehovs") {
-                    var callCount = 0
-                    coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } answers {
-                        callCount++
-                        if (callCount == 1) {
-                            throw RuntimeException("Test exception")
-                        }
-                    }
-
-                    val task = createTask()
-
-                    val job = launch {
-                        task.runTask()
-                    }
-
-                    delay(150.milliseconds)
-                    job.cancelAndJoin()
-
-                    coVerify(atLeast = 2) { narmestelederService.updateStatusOnExpiredBehovs(any()) }
                 }
 
                 it("should use correct daysAfterTomToExpireBehovs value") {
@@ -90,7 +69,7 @@ class BehovMaintenanceTaskTest :
                     val customEnv = env.copy(daysAfterTomToExpireBehovs = customDays)
                     val task = BehovMaintenanceTask(
                         narmestelederService = narmestelederService,
-                        env = customEnv
+                        env = customEnv,
                     )
 
                     coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } just Runs
@@ -105,20 +84,6 @@ class BehovMaintenanceTaskTest :
                     coVerify(atLeast = 1) {
                         narmestelederService.updateStatusOnExpiredBehovs(eq(customDays))
                     }
-                }
-
-                it("should gracefully handle cancellation") {
-                    coEvery { narmestelederService.updateStatusOnExpiredBehovs(any()) } just Runs
-
-                    val task = createTask()
-
-                    val job = launch {
-                        task.runTask()
-                    }
-
-                    delay(50.milliseconds)
-
-                    job.cancelAndJoin()
                 }
             }
         }


### PR DESCRIPTION
## Beskrivelse

Erstatter polling-basert leader election i de tre schedulerte taskene med reaktive Ktor leader events. Tasks er nå rene arbeidsløkker; `ConfigureTasks.kt` abonnerer på `LeaderChangeEvent` og styrer task-lifecycle (launch på `Promoted`, cancel på `Demoted`).

I tillegg er det felles boilerplate (while-loop, try/catch, delay) abstrahert inn i `ScheduledLeaderTask` som base class, slik at hver task kun implementerer `execute()`.

## Endringer

- `application/task/ScheduledLeaderTask.kt`: Ny abstrakt klasse med while-loop, feilhåndtering, delay og korrekt `CancellationException`-håndtering
- `altinn/dialogporten/task/SendDialogTask.kt`: Fjernet `LeaderElection`-avhengighet, utvider `ScheduledLeaderTask`
- `altinn/dialogporten/task/UpdateDialogTask.kt`: Fjernet `LeaderElection`-avhengighet, utvider `ScheduledLeaderTask`
- `narmesteleder/task/BehovMaintenanceTask.kt`: Fjernet `LeaderElection`-avhengighet, utvider `ScheduledLeaderTask`
- `plugins/ConfigureTasks.kt`: Erstattet `ApplicationStarted`/`ApplicationStopping` med `LeaderChangeEvent`-abonnement
- `plugins/DependencyInjection.kt`: Fjernet `LeaderElection` Koin-binding og oppdatert task-konstruktører
- `application/task/ScheduledLeaderTaskTest.kt`: Deterministiske tester med `runTest`/`advanceTimeBy`
- `dialogporten/task/SendDialogTaskTest.kt`: Ny test
- `dialogporten/task/UpdateDialogTaskTest.kt`: Forenklet (atferdstester)
- `narmesteleder/task/BehovMaintenanceTaskTest.kt`: Forenklet (atferdstester)

## Issue

Closes #304
Del av epic: #302

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)