### PR TITLE
Remove employment requirement for narmesteleder

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
@@ -31,11 +31,8 @@ class ValidationService(
         val sykmeldtArbeidsforhold =
             aaregService.findArbeidsforholdByPersonIdent(linemanager.employeeIdentificationNumber)
 
-        val nlArbeidsforhold =
-            aaregService.findArbeidsforholdByPersonIdent(linemanager.manager.nationalIdentificationNumber)
-        ArbeidsforholdValidator.validateSmAndNlArbeidsforhold(
+        ArbeidsforholdValidator.validateSmArbeidsforhold(
             sykmeldtArbeidsforhold = sykmeldtArbeidsforhold,
-            narmesteLederArbeidsforhold = nlArbeidsforhold,
             orgNumberInRequest = linemanager.orgNumber,
         )
 

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/validators/ArbeidsforholdValidator.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/validators/ArbeidsforholdValidator.kt
@@ -2,13 +2,11 @@ package no.nav.syfo.narmesteleder.service.validators
 
 import no.nav.syfo.aareg.Arbeidsforhold
 import no.nav.syfo.aareg.getForOrgnummer
-import no.nav.syfo.aareg.toOrgNumberList
 import no.nav.syfo.application.api.ErrorType
 
 object ArbeidsforholdValidator {
-    fun validateSmAndNlArbeidsforhold(
+    fun validateSmArbeidsforhold(
         sykmeldtArbeidsforhold: List<Arbeidsforhold>,
-        narmesteLederArbeidsforhold: List<Arbeidsforhold>,
         orgNumberInRequest: String,
     ) {
         nlrequire(
@@ -20,14 +18,6 @@ object ArbeidsforholdValidator {
             matchingArbeidsforhold != null,
             type = ErrorType.EMPLOYEE_MISSING_EMPLOYMENT_IN_ORG,
         ) { "Employee on sick leave is missing employment in the organization indicated in the request" }
-        val allNlOrgNumbers = narmesteLederArbeidsforhold.toOrgNumberList()
-
-        nlrequire(
-            allNlOrgNumbers.any { matchingArbeidsforhold?.toOrgnummerList()?.contains(it) == true },
-            type = ErrorType.LINEMANAGER_MISSING_EMPLOYMENT_IN_ORG,
-        ) {
-            "Linemanager is missing employment in any branch under the parent organization of the employee on sick leave"
-        }
     }
 
     fun validateNarmesteLederAvkreft(

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Esyfo Narmesteleder API
-  version: 1.0.3
+  version: 1.0.4
   description: |
     API v1 for assigning line manager for employees on sick leave, removing existing line managers
     and to retrieve requirements for line managers for employees on sick leave.
@@ -71,7 +71,6 @@ paths:
             * `BAD_REQUEST`: The request was malformed or contained invalid data. Can also occur if we fail to lookup the person linked to the provided national identification number.
             * `NO_ACTIVE_SICK_LEAVE`: The employee does not have an active sick leave.
             * `EMPLOYEE_MISSING_EMPLOYMENT_IN_ORG`: The employee does not have an active employment in the specified organization.
-            * `LINEMANAGER_MISSING_EMPLOYMENT_IN_ORG`: The line manager does not have an active employment in any sub organization under the parent of the specified organization.
             * `LINEMANAGER_NAME_NATIONAL_IDENTIFICATION_NUMBER_MISMATCH`: The name provided for the line manager does not match the name registered with the provided national identification number.
             * `EMPLOYEE_NAME_NATIONAL_IDENTIFICATION_NUMBER_MISMATCH`: The name provided for the employee does not match the name registered with the provided national identification number.
           content:
@@ -284,7 +283,6 @@ paths:
         - The employee must have an active sick leave, with a grace period of 16 additional days after the end of the sick leave.
           We will automatically close the requirement due to en expired sick leave,
           but it is done by a scheduled job so there might be a delay between the sick leave expiring and the requirement being closed in the system.
-        - The line manager must have an active employment in any sub organization under the parent of the specified organization.
         - The lastname provided for the line manager must match the name registered with the provided national identification number.
       tags: [ requirement ]
       security:
@@ -314,7 +312,6 @@ paths:
             * `BAD_REQUEST`: The request was malformed or contained invalid data. Can also occur if we fail to lookup the person linked to the provided national identification number.
             * `NO_ACTIVE_SICK_LEAVE`: The employee does not have an active sick leave.
             * `EMPLOYEE_MISSING_EMPLOYMENT_IN_ORG`: The employee does not have an active employment in the specified organization.
-            * `LINEMANAGER_MISSING_EMPLOYMENT_IN_ORG`: The line manager does not have an active employment in any sub organization under the parent of the specified organization.
             * `LINEMANAGER_NAME_NATIONAL_IDENTIFICATION_NUMBER_MISMATCH`: The name provided for the line manager does not match the name registered with the provided national identification number.
           content:
             application/json:
@@ -641,7 +638,7 @@ components:
         * `BAD_REQUEST`: The request was malformed or contained invalid data.
         * `INVALID_FORMAT`: The request contained json data in invalid format and could not be deserialized.
         * `CONFLICT`: The request could not be completed due to a conflict with the current state of the resource.
-        * `LINEMANAGER_MISSING_EMPLOYMENT_IN_ORG`: The linemanager does not have an active employment in any sub organization under the parent of the specified organization.
+        * `LINEMANAGER_MISSING_EMPLOYMENT_IN_ORG`: Deprecated: The linemanager does not have an active employment in any sub organization under the parent of the specified organization.
         * `EMPLOYEE_MISSING_EMPLOYMENT_IN_ORG`: The employee does not have an active employment in the specified organization.
         * `LINEMANAGER_NAME_NATIONAL_IDENTIFICATION_NUMBER_MISMATCH`: The name provided for the linemanager does not match the name registered with the provided national identification number.
         * `EMPLOYEE_NAME_NATIONAL_IDENTIFICATION_NUMBER_MISMATCH`: The name provided for the employee does not match the name registered with the provided national identification number.

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
@@ -142,7 +142,6 @@ class ValidationServiceTest :
                     pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber)
                     pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.employeeIdentificationNumber)
                     aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.employeeIdentificationNumber)
-                    aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber)
                 }
                 coVerify(exactly = 0) {
                     pdpService.hasAccessToResource(any(), any(), any())
@@ -172,7 +171,6 @@ class ValidationServiceTest :
                     pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber)
                     pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.employeeIdentificationNumber)
                     aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.employeeIdentificationNumber)
-                    aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber)
                 }
                 coVerify(exactly = 0) {
                     pdpService.hasAccessToResource(any(), any(), any())
@@ -291,7 +289,6 @@ class ValidationServiceTest :
                         resource = eq("nav_syfo_oppgi-narmesteleder"),
                     )
                     aaregService.findArbeidsforholdByPersonIdent(eq(narmestelederRelasjonerWrite.employeeIdentificationNumber))
-                    aaregService.findArbeidsforholdByPersonIdent(eq(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber))
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/validators/ArbeidsforholdValidatorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/validators/ArbeidsforholdValidatorTest.kt
@@ -35,14 +35,8 @@ class ArbeidsforholdValidatorTest :
         describe("validateSmAndNlArbeidsforhold") {
             it("should not throw when sykmeldt and nearest leader have overlapping organization numbers") {
                 shouldNotThrowAny {
-                    ArbeidsforholdValidator.validateSmAndNlArbeidsforhold(
+                    ArbeidsforholdValidator.validateSmArbeidsforhold(
                         sykmeldtArbeidsforhold = listOf(sykmeldtArbeidsforhold),
-                        narmesteLederArbeidsforhold = listOf(
-                            arbeidsforhold(
-                                orgnummer = sykmeldtArbeidsforhold.orgnummer,
-                                opplysningspliktigOrgnummer = requireNotNull(sykmeldtArbeidsforhold.opplysningspliktigOrgnummer),
-                            ),
-                        ),
                         orgNumberInRequest = sykmeldtArbeidsforhold.orgnummer,
                     )
                 }
@@ -50,9 +44,8 @@ class ArbeidsforholdValidatorTest :
 
             it("should throw BadRequestException when sykmeldt has no arbeidsforhold") {
                 shouldThrow<ApiErrorException.BadRequestException> {
-                    ArbeidsforholdValidator.validateSmAndNlArbeidsforhold(
+                    ArbeidsforholdValidator.validateSmArbeidsforhold(
                         sykmeldtArbeidsforhold = emptyList(),
-                        narmesteLederArbeidsforhold = listOf(sykmeldtArbeidsforhold),
                         orgNumberInRequest = sykmeldtArbeidsforhold.orgnummer,
                     )
                 }
@@ -60,25 +53,9 @@ class ArbeidsforholdValidatorTest :
 
             it("should throw BadRequestException when sykmeldt is missing arbeidsforhold for request org") {
                 shouldThrow<ApiErrorException.BadRequestException> {
-                    ArbeidsforholdValidator.validateSmAndNlArbeidsforhold(
+                    ArbeidsforholdValidator.validateSmArbeidsforhold(
                         sykmeldtArbeidsforhold = listOf(sykmeldtArbeidsforhold),
-                        narmesteLederArbeidsforhold = listOf(sykmeldtArbeidsforhold),
                         orgNumberInRequest = randomOrgNumbers[2],
-                    )
-                }
-            }
-
-            it("should throw BadRequestException when nearest leader has no matching organization with sykmeldt") {
-                shouldThrow<ApiErrorException.BadRequestException> {
-                    ArbeidsforholdValidator.validateSmAndNlArbeidsforhold(
-                        sykmeldtArbeidsforhold = listOf(sykmeldtArbeidsforhold),
-                        narmesteLederArbeidsforhold = listOf(
-                            arbeidsforhold(
-                                orgnummer = randomOrgNumbers[2],
-                                opplysningspliktigOrgnummer = randomOrgNumbers[3],
-                            ),
-                        ),
-                        orgNumberInRequest = sykmeldtArbeidsforhold.orgnummer,
                     )
                 }
             }


### PR DESCRIPTION
We remove the requirement that the narmesteLeder is employed in the same org as the sykmeldt.
