### PR TITLE
feat: introduce value classes for OrganizationNumber and PersonalIdentificationNumber

### DIFF
--- a/local-dev-resources/kafka/narmesteleder-leesah/create-nl_behov.json
+++ b/local-dev-resources/kafka/narmesteleder-leesah/create-nl_behov.json
@@ -2,7 +2,7 @@
   "narmesteLederId": "0199b8f1-0cfe-7787-bab8-2fb1cf1b4767",
   "fnr": "15436803416",
   "orgnummer": "215649202",
-  "narmesteLederFnr": "215649202",
+  "narmesteLederFnr": "13468329780",
   "narmesteLederTelefonnummer": "12346532",
   "narmesteLederEpost": "e@post.no",
   "arbeidsgiverForskutterer": "false",

--- a/local-dev-resources/kafka/narmesteleder-leesah/update-nl_behov-due-to-aktivTOM-not-null.json
+++ b/local-dev-resources/kafka/narmesteleder-leesah/update-nl_behov-due-to-aktivTOM-not-null.json
@@ -2,7 +2,7 @@
   "narmesteLederId": "0199b8f1-0cfe-7787-bab8-2fb1cf1b4767",
   "fnr": "15436803416",
   "orgnummer": "215649202",
-  "narmesteLederFnr": "215649202",
+  "narmesteLederFnr": "13468329780",
   "narmesteLederTelefonnummer": "12346532",
   "narmesteLederEpost": "e@post.no",
   "arbeidsgiverForskutterer": "false",

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.application.api
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinInvalidNullException
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -72,19 +73,30 @@ fun Application.installStatusPages() {
 
 fun BadRequestException.toApiError(path: String?): ApiError {
     val rootCause = this.rootCause()
-    return if (rootCause is KotlinInvalidNullException) {
-        ApiErrorException.BadRequestException(
-            "Invalid request body. Missing required field: ${rootCause.propertyName}",
-            type = ErrorType.INVALID_FORMAT
-        )
-            .toApiError(path ?: "")
-    } else {
-        ApiError(
-            status = HttpStatusCode.BadRequest,
-            type = ErrorType.BAD_REQUEST,
-            message = this.message ?: "Bad request",
-            path = path
-        )
+    return when (rootCause) {
+        is KotlinInvalidNullException -> {
+            ApiErrorException.BadRequestException(
+                "Invalid request body. Missing required field: ${rootCause.propertyName}",
+                type = ErrorType.INVALID_FORMAT
+            ).toApiError(path ?: "")
+        }
+
+        is IllegalArgumentException,
+        is ValueInstantiationException -> {
+            ApiErrorException.BadRequestException(
+                rootCause.message ?: "Invalid request body",
+                type = ErrorType.INVALID_FORMAT
+            ).toApiError(path ?: "")
+        }
+
+        else -> {
+            ApiError(
+                status = HttpStatusCode.BadRequest,
+                type = ErrorType.BAD_REQUEST,
+                message = this.message ?: "Bad request",
+                path = path
+            )
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/Functions.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/Functions.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.application.auth.UserPrincipal
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.exceptions.UnauthorizedException
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementCollection
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
 import java.time.Instant
 import java.time.format.DateTimeParseException
 import java.util.UUID
@@ -37,6 +38,14 @@ fun RoutingCall.getUUIDFromPathVariable(name: String): UUID {
 fun RoutingCall.getPathVariable(name: String): String = this.parameters[name] ?: throw ApiErrorException.BadRequestException("Missing $name parameter")
 
 fun RoutingCall.getRequiredQueryParameter(name: String): String = this.queryParameters[name] ?: throw ApiErrorException.BadRequestException("Missing $name parameter")
+
+fun RoutingCall.getRequiredOrganizationNumberQueryParameter(name: String): OrganizationNumber = OrganizationNumber.parse(getRequiredQueryParameter(name))
+    .getOrElse {
+        throw ApiErrorException.BadRequestException(
+            it.message ?: "Invalid organization number format for $name parameter",
+            type = ErrorType.INVALID_FORMAT
+        )
+    }
 
 fun RoutingCall.getCreatedAfter(): Instant {
     val createdAfter = getRequiredQueryParameter("createdAfter")

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
@@ -100,7 +100,7 @@ fun Route.registerLinemanagerApiV1(
         get {
             val pageSize = call.getPageSize()
             val createAfter = call.getCreatedAfter()
-            val orgNumber = call.getRequiredQueryParameter("orgNumber")
+            val orgNumber = call.getRequiredOrganizationNumberQueryParameter("orgNumber")
             val principal = call.getMyPrincipal()
             val collection = linemanagerRequirementRestHandler.handleGetLinemanagerRequirementsCollection(
                 pageSize = pageSize,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.narmesteleder.domain.BehovStatus
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementRead
 import no.nav.syfo.narmesteleder.domain.Manager
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
 import no.nav.syfo.narmesteleder.exception.HovedenhetNotFoundException
 import no.nav.syfo.narmesteleder.exception.LinemanagerRequirementNotFoundException
 import no.nav.syfo.narmesteleder.kafka.model.NlResponseSource
@@ -83,11 +84,11 @@ class LinemanagerRequirementRESTHandler(
     suspend fun handleGetLinemanagerRequirementsCollection(
         pageSize: Int,
         createdAfter: Instant,
-        orgNumber: String,
+        orgNumber: OrganizationNumber,
         principal: Principal
     ): List<LinemanagerRequirementRead> {
         val orgName = validationService.validatePrincipalAccessToOrgnumber(principal, orgNumber)
-        logger.info("Validation successful for fetching LinemanagerRequirement collection for orgNumber: $orgNumber")
+        logger.info("Validation successful for fetching LinemanagerRequirement collection for orgNumber: ${orgNumber.value}")
         return narmesteLederService.getNlBehovList(
             pageSize = pageSize,
             createdAfter = createdAfter,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/db/Entities.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/db/Entities.kt
@@ -33,10 +33,10 @@ data class NarmestelederBehovEntity(
         ): NarmestelederBehovEntity {
             with(linemanagerRequirementWrite) {
                 return NarmestelederBehovEntity(
-                    orgnummer = orgNumber,
+                    orgnummer = orgNumber.value,
                     hovedenhetOrgnummer = hovedenhetOrgnummer,
-                    sykmeldtFnr = employeeIdentificationNumber,
-                    narmestelederFnr = managerIdentificationNumber,
+                    sykmeldtFnr = employeeIdentificationNumber.value,
+                    narmestelederFnr = managerIdentificationNumber?.value,
                     behovReason = behovReason,
                     avbruttNarmesteLederId = revokedLinemanagerId,
                     behovStatus = behovStatus,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/Employee.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/Employee.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.narmesteleder.domain
 
 data class Employee(
-    val nationalIdentificationNumber: String,
-    val orgNumber: String,
+    val nationalIdentificationNumber: PersonalIdentificationNumber,
+    val orgNumber: OrganizationNumber,
     val lastName: String,
 )

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/Linemanager.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/Linemanager.kt
@@ -1,8 +1,8 @@
 package no.nav.syfo.narmesteleder.domain
 
 data class Linemanager(
-    val employeeIdentificationNumber: String,
+    val employeeIdentificationNumber: PersonalIdentificationNumber,
     val lastName: String,
-    val orgNumber: String,
+    val orgNumber: OrganizationNumber,
     val manager: Manager,
 )

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementRead.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementRead.kt
@@ -5,11 +5,11 @@ import java.util.UUID
 
 data class LinemanagerRequirementRead(
     val id: UUID,
-    val employeeIdentificationNumber: String,
-    val orgNumber: String,
+    val employeeIdentificationNumber: PersonalIdentificationNumber,
+    val orgNumber: OrganizationNumber,
     val orgName: String? = null,
-    val mainOrgNumber: String,
-    val managerIdentificationNumber: String? = null,
+    val mainOrgNumber: OrganizationNumber,
+    val managerIdentificationNumber: PersonalIdentificationNumber? = null,
     val name: Name,
     val created: Instant,
     val updated: Instant,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementWrite.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementWrite.kt
@@ -3,9 +3,9 @@ package no.nav.syfo.narmesteleder.domain
 import java.util.UUID
 
 data class LinemanagerRequirementWrite(
-    val employeeIdentificationNumber: String,
-    val orgNumber: String,
-    val managerIdentificationNumber: String? = null,
+    val employeeIdentificationNumber: PersonalIdentificationNumber,
+    val orgNumber: OrganizationNumber,
+    val managerIdentificationNumber: PersonalIdentificationNumber? = null,
     val behovReason: BehovReason,
     val revokedLinemanagerId: UUID? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRevoke.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRevoke.kt
@@ -3,12 +3,12 @@ package no.nav.syfo.narmesteleder.domain
 import no.nav.syfo.narmesteleder.kafka.model.NlAvbrutt
 
 data class LinemanagerRevoke(
-    val employeeIdentificationNumber: String,
-    val orgNumber: String,
+    val employeeIdentificationNumber: PersonalIdentificationNumber,
+    val orgNumber: OrganizationNumber,
     val lastName: String,
 ) {
     fun toNlAvbrutt(): NlAvbrutt = NlAvbrutt(
-        orgnummer = orgNumber,
-        sykmeldtFnr = employeeIdentificationNumber,
+        orgnummer = orgNumber.value,
+        sykmeldtFnr = employeeIdentificationNumber.value,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/Manager.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/Manager.kt
@@ -4,13 +4,13 @@ import no.nav.syfo.narmesteleder.kafka.model.Leder
 import no.nav.syfo.pdl.Person
 
 data class Manager(
-    val nationalIdentificationNumber: String,
+    val nationalIdentificationNumber: PersonalIdentificationNumber,
     val lastName: String,
     val email: String,
     val mobile: String,
 ) {
     fun toLeder(person: Person) = Leder(
-        fnr = nationalIdentificationNumber,
+        fnr = nationalIdentificationNumber.value,
         mobil = mobile,
         epost = email,
         fornavn = person.name.fornavn,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/OrganizationNumber.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/OrganizationNumber.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.narmesteleder.domain
+
+@JvmInline
+value class OrganizationNumber(val value: String) {
+    init {
+        require(value.length == 9 && value.all { it.isDigit() }) {
+            "OrganizationNumber must be exactly 9 digits"
+        }
+    }
+
+    companion object {
+        fun parse(value: String): Result<OrganizationNumber> = runCatching { OrganizationNumber(value) }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/PersonalIdentificationNumber.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/PersonalIdentificationNumber.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.narmesteleder.domain
+
+@JvmInline
+value class PersonalIdentificationNumber(val value: String) {
+    init {
+        require(value.length == 11 && value.all { it.isDigit() }) {
+            "PersonalIdentificationNumber must be exactly 11 digits"
+        }
+    }
+
+    companion object {
+        fun parse(value: String): Result<PersonalIdentificationNumber> = runCatching { PersonalIdentificationNumber(value) }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/model/NarmestelederLeesahKafkaMessage.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/model/NarmestelederLeesahKafkaMessage.kt
@@ -3,6 +3,8 @@ package no.nav.syfo.narmesteleder.kafka.model
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import no.nav.syfo.narmesteleder.domain.BehovReason
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementWrite
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -37,9 +39,9 @@ data class NarmestelederLeesahKafkaMessage(
 ) {
 
     fun toNlBehovWrite() = LinemanagerRequirementWrite(
-        employeeIdentificationNumber = fnr,
-        orgNumber = orgnummer,
-        managerIdentificationNumber = narmesteLederFnr,
+        employeeIdentificationNumber = PersonalIdentificationNumber(fnr),
+        orgNumber = OrganizationNumber(orgnummer),
+        managerIdentificationNumber = PersonalIdentificationNumber(narmesteLederFnr),
         behovReason = status?.name?.let { BehovReason.valueOf(it) }
             ?: BehovReason.UKJENT,
         revokedLinemanagerId = narmesteLederId,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/model/NlResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/model/NlResponse.kt
@@ -17,7 +17,7 @@ data class Sykmeldt(
         fun from(person: Person): Sykmeldt {
             with(person.name) {
                 return Sykmeldt(
-                    fnr = person.nationalIdentificationNumber,
+                    fnr = person.nationalIdentificationNumber.value,
                     navn = listOfNotNull(fornavn, mellomnavn, etternavn).joinToString(" "),
                 )
             }
@@ -35,7 +35,7 @@ data class Leder(
     fun updateFromPerson(person: Person): Leder {
         with(person.name) {
             return Leder(
-                fnr = person.nationalIdentificationNumber,
+                fnr = person.nationalIdentificationNumber.value,
                 fornavn = listOfNotNull(fornavn, mellomnavn).joinToString(" "),
                 etternavn = etternavn,
                 mobil = mobil,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/model/NlResponseSource.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/kafka/model/NlResponseSource.kt
@@ -24,7 +24,7 @@ enum class NlResponseSource(val source: String) {
             is SystemPrincipal -> LPS_REVOKE
             is UserPrincipal -> {
                 when (principal.ident) { // Can add option for NARMESTELEDER if we accept requests from them and can identity the caller as such
-                    linemanagerRevoke.employeeIdentificationNumber -> ARBEIDSTAGER_REVOKE
+                    linemanagerRevoke.employeeIdentificationNumber.value -> ARBEIDSTAGER_REVOKE
                     else -> PERSONALLEDER_REVOKE
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederKafkaService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederKafkaService.kt
@@ -21,7 +21,7 @@ class NarmestelederKafkaService(
             NlResponse(
                 sykmeldt = Sykmeldt.from(linemanagerActors.employee),
                 leder = linemanager.manager.toLeder(linemanagerActors.manager),
-                orgnummer = linemanager.orgNumber,
+                orgnummer = linemanager.orgNumber.value,
                 // I den tidligere nærmeste leder-løsningen ble det rapportert hvorvidt arbeidsgiver forskutterer lønn i samme skjema som
                 // nærmeste leder. Ved overgangen til Altinn 3 og overføringen av NL til esyfo, gikk man bort fra dette.
                 // Denne settes til true for bakoverkompabilitet på Kafka-meldingene fram til helseytelser er ute av Altinn 2.
@@ -37,8 +37,8 @@ class NarmestelederKafkaService(
     ) {
         kafkaSykemeldingProducer.sendSykmldingNLBrudd(
             NlAvbrutt(
-                sykmeldtFnr = linemanagerRevoke.employeeIdentificationNumber,
-                orgnummer = linemanagerRevoke.orgNumber,
+                sykmeldtFnr = linemanagerRevoke.employeeIdentificationNumber.value,
+                orgnummer = linemanagerRevoke.orgNumber.value,
             ),
             source = source
         )

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
@@ -12,6 +12,8 @@ import no.nav.syfo.narmesteleder.domain.LineManagerRequirementStatus
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementRead
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementWrite
 import no.nav.syfo.narmesteleder.domain.Name
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.domain.RevokedBy
 import no.nav.syfo.narmesteleder.exception.LinemanagerRequirementNotFoundException
 import no.nav.syfo.narmesteleder.exception.MissingIDException
@@ -112,8 +114,8 @@ class NarmestelederService(
             getStatusAndHovedEnhetOrgnummerFromArbeidsgiver(arbeidsgiver, behovSource)
         } else {
             getStatusAndHovedEnhetOrgnummerFromArbeidsforhold(
-                fnr = nlBehov.employeeIdentificationNumber,
-                orgnummer = nlBehov.orgNumber,
+                fnr = nlBehov.employeeIdentificationNumber.value,
+                orgnummer = nlBehov.orgNumber.value,
                 behovSource = behovSource,
             )
         }
@@ -137,7 +139,7 @@ class NarmestelederService(
         skipSykmeldingCheck: Boolean
     ): Boolean {
         val isActiveSykmelding = skipSykmeldingCheck ||
-            dinesykmeldteService.getIsActiveSykmelding(nlBehov.employeeIdentificationNumber, nlBehov.orgNumber)
+            dinesykmeldteService.getIsActiveSykmelding(nlBehov.employeeIdentificationNumber.value, nlBehov.orgNumber.value)
         return if (!isActiveSykmelding) {
             COUNT_CREATE_BEHOV_SKIPPED_NO_SICKLEAVE.increment()
             logger.info(
@@ -151,7 +153,7 @@ class NarmestelederService(
     }
 
     private suspend fun skipDueToExistingBehov(nlBehov: LinemanagerRequirementWrite): Boolean {
-        val registeredPreviousBehov = findClosableBehovs(nlBehov.employeeIdentificationNumber, nlBehov.orgNumber)
+        val registeredPreviousBehov = findClosableBehovs(nlBehov.employeeIdentificationNumber.value, nlBehov.orgNumber.value)
             .isNotEmpty()
 
         return if (registeredPreviousBehov) {
@@ -209,18 +211,18 @@ class NarmestelederService(
     suspend fun getEmployeeByRequirementId(id: UUID): Employee {
         val behovEntity = findBehovEntityById(id)
         return Employee(
-            nationalIdentificationNumber = behovEntity.sykmeldtFnr,
-            orgNumber = behovEntity.orgnummer,
+            nationalIdentificationNumber = PersonalIdentificationNumber(behovEntity.sykmeldtFnr),
+            orgNumber = OrganizationNumber(behovEntity.orgnummer),
             lastName = behovEntity.etternavn ?: "",
         )
     }
 
     suspend fun getNlBehovList(
-        orgNumber: String,
+        orgNumber: OrganizationNumber,
         createdAfter: Instant,
         pageSize: Int
     ): List<LinemanagerRequirementRead> = nlDb.findBehovByParameters(
-        orgNumber = orgNumber,
+        orgNumber = orgNumber.value,
         createdAfter = createdAfter,
         status = listOf(BehovStatus.BEHOV_CREATED, BehovStatus.DIALOGPORTEN_STATUS_SET_REQUIRES_ATTENTION),
         limit = pageSize + 1,
@@ -253,10 +255,10 @@ class NarmestelederService(
 
 fun NarmestelederBehovEntity.toEmployeeLinemanagerRead(name: Name): LinemanagerRequirementRead = LinemanagerRequirementRead(
     id = this.id ?: throw MissingIDException("NarmestelederBehovEntity entity id is null"),
-    employeeIdentificationNumber = this.sykmeldtFnr,
-    orgNumber = this.orgnummer,
-    mainOrgNumber = this.hovedenhetOrgnummer,
-    managerIdentificationNumber = this.narmestelederFnr,
+    employeeIdentificationNumber = PersonalIdentificationNumber(this.sykmeldtFnr),
+    orgNumber = OrganizationNumber(this.orgnummer),
+    mainOrgNumber = OrganizationNumber(this.hovedenhetOrgnummer),
+    managerIdentificationNumber = this.narmestelederFnr?.let(::PersonalIdentificationNumber),
     name = name,
     created = this.created,
     updated = this.updated,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.application.auth.Principal
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerActors
 import no.nav.syfo.narmesteleder.domain.LinemanagerRevoke
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
 import no.nav.syfo.narmesteleder.service.validators.ArbeidsforholdValidator
 import no.nav.syfo.narmesteleder.service.validators.NameValidator
 import no.nav.syfo.narmesteleder.service.validators.PrincipalAccessValidator
@@ -25,19 +26,19 @@ class ValidationService(
     ): LinemanagerActors {
         principalAccessValidator.validatePrincipalAccessToOrgnumber(
             principal,
-            linemanager.orgNumber,
+            linemanager.orgNumber.value,
         )
-        sickLeaveValidator.validateActiveSickLeave(linemanager.employeeIdentificationNumber, linemanager.orgNumber)
+        sickLeaveValidator.validateActiveSickLeave(linemanager.employeeIdentificationNumber.value, linemanager.orgNumber.value)
         val sykmeldtArbeidsforhold =
-            aaregService.findArbeidsforholdByPersonIdent(linemanager.employeeIdentificationNumber)
+            aaregService.findArbeidsforholdByPersonIdent(linemanager.employeeIdentificationNumber.value)
 
         ArbeidsforholdValidator.validateSmArbeidsforhold(
             sykmeldtArbeidsforhold = sykmeldtArbeidsforhold,
-            orgNumberInRequest = linemanager.orgNumber,
+            orgNumberInRequest = linemanager.orgNumber.value,
         )
 
-        val sykmeldt = pdlService.getPersonOrThrowApiError(linemanager.employeeIdentificationNumber)
-        val leder = pdlService.getPersonOrThrowApiError(linemanager.manager.nationalIdentificationNumber)
+        val sykmeldt = pdlService.getPersonOrThrowApiError(linemanager.employeeIdentificationNumber.value)
+        val leder = pdlService.getPersonOrThrowApiError(linemanager.manager.nationalIdentificationNumber.value)
         NameValidator.validateLinemanagerLastName(leder, linemanager)
         if (validateEmployeeLastName) {
             NameValidator.validateEmployeeLastName(sykmeldt, linemanager)
@@ -54,16 +55,16 @@ class ValidationService(
         principal: Principal,
     ): Person {
         val arbeidsforhold =
-            aaregService.findArbeidsforholdByPersonIdent(linemanagerRevoke.employeeIdentificationNumber)
+            aaregService.findArbeidsforholdByPersonIdent(linemanagerRevoke.employeeIdentificationNumber.value)
         principalAccessValidator.validatePrincipalAccessToOrgnumber(
             principal,
-            linemanagerRevoke.orgNumber,
+            linemanagerRevoke.orgNumber.value,
         )
         ArbeidsforholdValidator.validateNarmesteLederAvkreft(
-            orgNumberInRequest = linemanagerRevoke.orgNumber,
+            orgNumberInRequest = linemanagerRevoke.orgNumber.value,
             sykmeldtArbeidsforhold = arbeidsforhold,
         )
-        val sykmeldt = pdlService.getPersonOrThrowApiError(linemanagerRevoke.employeeIdentificationNumber)
+        val sykmeldt = pdlService.getPersonOrThrowApiError(linemanagerRevoke.employeeIdentificationNumber.value)
         NameValidator.validateEmployeeLastName(sykmeldt, linemanagerRevoke)
 
         return sykmeldt
@@ -71,9 +72,6 @@ class ValidationService(
 
     suspend fun validatePrincipalAccessToOrgnumber(
         principal: Principal,
-        orgNumber: String,
-    ): String? = principalAccessValidator.validatePrincipalAccessToOrgnumber(
-        principal,
-        orgNumber,
-    )
+        orgNumber: OrganizationNumber,
+    ): String? = principalAccessValidator.validatePrincipalAccessToOrgnumber(principal, orgNumber.value)
 }

--- a/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
@@ -97,7 +97,7 @@ class PdlService(
                 val navn = bolk.person.navn?.firstOrNull() ?: return@mapValues null
                 Person(
                     name = navn,
-                    nationalIdentificationNumber = bolk.ident,
+                    nationalIdentificationNumber = PersonalIdentificationNumber(bolk.ident),
                     foedselsdato = bolk.person.foedselsdato?.firstOrNull(),
                 )
             } else {

--- a/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.valkey.PdlCache
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.pdl.client.GetPersonBolkResponse
 import no.nav.syfo.pdl.client.IPdlClient
 import no.nav.syfo.pdl.client.Ident.Companion.GRUPPE_IDENT_FNR
@@ -31,7 +32,7 @@ class PdlService(
             val foedselsdato = response.data.person.foedselsdato?.firstOrNull()
             return Person(
                 name = navn,
-                nationalIdentificationNumber = fnr,
+                nationalIdentificationNumber = PersonalIdentificationNumber(fnr),
                 foedselsdato = foedselsdato,
             )
         }

--- a/src/main/kotlin/no/nav/syfo/pdl/Person.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/Person.kt
@@ -1,10 +1,11 @@
 package no.nav.syfo.pdl
 
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.pdl.client.Foedselsdato
 import no.nav.syfo.pdl.client.Navn
 
 data class Person(
     val name: Navn,
-    val nationalIdentificationNumber: String,
+    val nationalIdentificationNumber: PersonalIdentificationNumber,
     val foedselsdato: Foedselsdato? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandler.kt
@@ -33,6 +33,15 @@ class SendtSykmeldingHandler(
                     return
                 }
 
+            if (!message.kafkaMetadata.fnr.isDigitsWithLength(FNR_LENGTH)) {
+                logger.warn("Invalid fnr in sendt sykmelding with sykmeldingId: ${message.event.sykmeldingId}. Skipping NL behov creation.")
+                return
+            }
+            if (!arbeidsgiver.orgnummer.isDigitsWithLength(ORGNUMMER_LENGTH)) {
+                logger.warn("Invalid orgnummer in sendt sykmelding with sykmeldingId: ${message.event.sykmeldingId}. Skipping NL behov creation.")
+                return
+            }
+
             narmesteLederService.createNewNlBehov(
                 nlBehov = LinemanagerRequirementWrite(
                     employeeIdentificationNumber = PersonalIdentificationNumber(message.kafkaMetadata.fnr),
@@ -47,5 +56,12 @@ class SendtSykmeldingHandler(
         } else {
             logger.info("Employee has answered riktigNarmesteLeder for sykmeldingId: ${message.event.sykmeldingId}. No NL behov created.")
         }
+    }
+
+    private fun String.isDigitsWithLength(length: Int): Boolean = this.length == length && all(Char::isDigit)
+
+    companion object {
+        private const val FNR_LENGTH = 11
+        private const val ORGNUMMER_LENGTH = 9
     }
 }

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandler.kt
@@ -2,6 +2,8 @@ package no.nav.syfo.sykmelding.kafka
 
 import no.nav.syfo.narmesteleder.domain.BehovReason
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementWrite
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.service.BehovSource
 import no.nav.syfo.narmesteleder.service.NarmestelederService
 import no.nav.syfo.sykmelding.model.SendtSykmeldingKafkaMessage
@@ -33,8 +35,8 @@ class SendtSykmeldingHandler(
 
             narmesteLederService.createNewNlBehov(
                 nlBehov = LinemanagerRequirementWrite(
-                    employeeIdentificationNumber = message.kafkaMetadata.fnr,
-                    orgNumber = arbeidsgiver.orgnummer,
+                    employeeIdentificationNumber = PersonalIdentificationNumber(message.kafkaMetadata.fnr),
+                    orgNumber = OrganizationNumber(arbeidsgiver.orgnummer),
                     behovReason = BehovReason.INGEN_LEDER_REGISTRERT,
                 ),
                 skipSykmeldingCheck = message.sykmelding.sykmeldingsperioder

--- a/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingKafkaConsumer.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.sykmelding.kafka
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.CoroutineName
@@ -49,6 +50,16 @@ class SendtSykmeldingKafkaConsumer(
                         }
                 } catch (_: WakeupException) {
                     logger.info("Waked Kafka consumer")
+                } catch (e: JsonProcessingException) {
+                    logger.error(
+                        "Failed to deserialize message from $SENDT_SYKMELDING_TOPIC. " +
+                            "The message will be retried in $DELAY_ON_ERROR_SECONDS seconds. " +
+                            "Manual inspection may be required if this persists. Cause: ${e.message}",
+                        e
+                    )
+                    kafkaConsumer.unsubscribe()
+                    delay(DELAY_ON_ERROR_SECONDS.seconds)
+                    kafkaConsumer.subscribe(listOf(SENDT_SYKMELDING_TOPIC))
                 } catch (e: Exception) {
                     logger.error(
                         "Error running kafka consumer. Waiting $DELAY_ON_ERROR_SECONDS seconds for retry.",

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -214,7 +214,7 @@ paths:
           description: Organization number (digits only)
           schema:
             type: string
-            pattern: '^\d+$'
+            pattern: '^\d{9}$'
         - name: pageSize
           in: query
           required: false
@@ -442,6 +442,7 @@ components:
           type: string
           description: "A Norwegian national identity number or D number."
           example: "12345678901"
+          pattern: '^\d{11}$'
         lastName:
           type: string
           description: The last name of the employee. Used to validate against the registered value in folkeregisteret. Validation is case-insensitive.
@@ -450,6 +451,7 @@ components:
           type: string
           description: Organization number where the employee works
           example: "123456789"
+          pattern: '^\d{9}$'
         manager:
           $ref: '#/components/schemas/Manager'
       required:
@@ -467,10 +469,12 @@ components:
           type: string
           description: "A Norwegian national identity number or D number."
           example: "12345678901"
+          pattern: '^\d{11}$'
         orgNumber:
           type: string
           description: Organization number where the employee works
           example: "123456789"
+          pattern: '^\d{9}$'
         lastName:
           type: string
           description: The last name of the employee.
@@ -489,6 +493,7 @@ components:
           type: string
           description: Norwegian national identity number or D number of the manager.
           example: "10987654321"
+          pattern: '^\d{11}$'
         lastName:
           type: string
           description: The last name of the manager. Used to validate against the registered value in folkeregisteret. Validation is case-insensitive.
@@ -521,10 +526,12 @@ components:
           type: string
           description: Norwegian national identity number or D number of the employee.
           example: "12345678901"
+          pattern: '^\d{11}$'
         orgNumber:
           type: string
           description: Organization number where the employee works.
           example: "123456789"
+          pattern: '^\d{9}$'
         orgName:
           type: string
           nullable: true
@@ -534,11 +541,13 @@ components:
           type: string
           description: Main (parent) organization number.
           example: "987654321"
+          pattern: '^\d{9}$'
         managerIdentificationNumber:
           type: string
           nullable: true
           description: Norwegian national identity number or D number of the manager, for the previous linemanager the employee had, if any.
           example: "10987654321"
+          pattern: '^\d{11}$'
         name:
           type: object
           description: Name of the employee on sick leave.

--- a/src/test/kotlin/TestUtil.kt
+++ b/src/test/kotlin/TestUtil.kt
@@ -17,6 +17,8 @@ import no.nav.syfo.narmesteleder.domain.BehovStatus
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerRevoke
 import no.nav.syfo.narmesteleder.domain.Manager
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.kafka.model.LeesahStatus
 import no.nav.syfo.narmesteleder.kafka.model.NarmestelederLeesahKafkaMessage
 import no.nav.syfo.pdl.PdlService
@@ -45,7 +47,7 @@ val faker = Faker(Random(Instant.now().epochSecond))
 
 fun faker() = faker
 fun manager(): Manager = Manager(
-    nationalIdentificationNumber = faker.numerify("###########"),
+    nationalIdentificationNumber = PersonalIdentificationNumber(faker.numerify("###########")),
     mobile = faker.phoneNumber().cellPhone(),
     email = faker.internet().emailAddress(),
     lastName = faker.name().lastName(),
@@ -53,8 +55,8 @@ fun manager(): Manager = Manager(
 
 fun linemanager(): Linemanager = Linemanager(
     manager = manager(),
-    employeeIdentificationNumber = faker.numerify("###########"),
-    orgNumber = faker.numerify("#########"),
+    employeeIdentificationNumber = PersonalIdentificationNumber(faker.numerify("###########")),
+    orgNumber = OrganizationNumber(faker.numerify("#########")),
     lastName = faker.name().lastName(),
 )
 
@@ -70,8 +72,8 @@ fun organisasjon() = Organisasjon(
 )
 
 fun linemanagerRevoke(): LinemanagerRevoke = LinemanagerRevoke(
-    employeeIdentificationNumber = faker.numerify("###########"),
-    orgNumber = faker.numerify("#########"),
+    employeeIdentificationNumber = PersonalIdentificationNumber(faker.numerify("###########")),
+    orgNumber = OrganizationNumber(faker.numerify("#########")),
     lastName = faker.name().lastName(),
 )
 
@@ -166,7 +168,7 @@ fun getMockEngine(path: String = "", status: HttpStatusCode, headers: Headers, c
 }
 
 fun PdlService.prepareGetPersonResponse(manager: Manager) {
-    prepareGetPersonResponse(manager.nationalIdentificationNumber, manager.lastName)
+    prepareGetPersonResponse(manager.nationalIdentificationNumber.value, manager.lastName)
 }
 
 fun PdlService.prepareGetPersonResponse(fnr: String, lastName: String) {
@@ -179,7 +181,7 @@ fun PdlService.prepareGetPersonResponse(fnr: String, lastName: String) {
             mellomnavn = "",
             etternavn = lastName,
         ),
-        nationalIdentificationNumber = fnr,
+        nationalIdentificationNumber = PersonalIdentificationNumber(fnr),
     )
 }
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandlerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandlerTest.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.narmesteleder.db.NarmestelederBehovEntity
 import no.nav.syfo.narmesteleder.domain.BehovReason
 import no.nav.syfo.narmesteleder.domain.BehovStatus
 import no.nav.syfo.narmesteleder.domain.Manager
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.kafka.model.NlResponseSource
 import prepareGetPersonResponse
 import java.util.*
@@ -28,7 +29,7 @@ class LinemanagerRequirementRESTHandlerTest :
         val arbeidsforholdManagerAareg = fakeAaregClient.arbeidsForholdForIdent[defaultManagerFnr]!!.first()
 
         val defaultManager = Manager(
-            nationalIdentificationNumber = defaultManagerFnr,
+            nationalIdentificationNumber = PersonalIdentificationNumber(defaultManagerFnr),
             mobile = "99999999",
             email = "mail@manager.no",
             lastName = "Jensen",
@@ -104,8 +105,8 @@ class LinemanagerRequirementRESTHandlerTest :
                 coVerify(exactly = 1) {
                     servicesWrapper.narmestelederKafkaServiceSpyk.sendNarmesteLederRelasjon(
                         match {
-                            it.employeeIdentificationNumber == fixtureEntity.sykmeldtFnr &&
-                                it.orgNumber == fixtureEntity.orgnummer
+                            it.employeeIdentificationNumber.value == fixtureEntity.sykmeldtFnr &&
+                                it.orgNumber.value == fixtureEntity.orgnummer
                         },
                         any(),
                         match { it == NlResponseSource.LPS }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
@@ -60,6 +60,8 @@ import no.nav.syfo.narmesteleder.domain.LinemanagerActors
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementCollection
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementRead
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementWrite
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.kafka.FakeSykmeldingNLKafkaProducer
 import no.nav.syfo.narmesteleder.kafka.model.NlResponseSource
 import no.nav.syfo.narmesteleder.service.BehovSource
@@ -179,26 +181,26 @@ class LinenmanagerApiV1Test :
                         // Arrange
                         pdlService.prepareGetPersonResponse(narmesteLederRelasjon.manager)
                         pdlService.prepareGetPersonResponse(
-                            narmesteLederRelasjon.employeeIdentificationNumber,
+                            narmesteLederRelasjon.employeeIdentificationNumber.value,
                             narmesteLederRelasjon.lastName,
                         )
                         texasHttpClientMock.defaultMocks(
                             systemBrukerOrganisasjon =
                             DefaultOrganization.copy(
-                                ID = "0192:${narmesteLederRelasjon.orgNumber}",
+                                ID = "0192:${narmesteLederRelasjon.orgNumber.value}",
                             ),
                             scope = MASKINPORTEN_NL_SCOPE,
                         )
-                        fakeAaregClient.arbeidsForholdForIdent[narmesteLederRelasjon.employeeIdentificationNumber] =
-                            listOf(narmesteLederRelasjon.orgNumber to narmesteLederRelasjon.orgNumber)
-                        fakeAaregClient.arbeidsForholdForIdent[narmesteLederRelasjon.manager.nationalIdentificationNumber] =
-                            listOf(narmesteLederRelasjon.orgNumber to narmesteLederRelasjon.orgNumber)
+                        fakeAaregClient.arbeidsForholdForIdent[narmesteLederRelasjon.employeeIdentificationNumber.value] =
+                            listOf(narmesteLederRelasjon.orgNumber.value to narmesteLederRelasjon.orgNumber.value)
+                        fakeAaregClient.arbeidsForholdForIdent[narmesteLederRelasjon.manager.nationalIdentificationNumber.value] =
+                            listOf(narmesteLederRelasjon.orgNumber.value to narmesteLederRelasjon.orgNumber.value)
                         // Act
                         val response =
                             client.post("/api/v1/linemanager") {
                                 contentType(ContentType.Application.Json)
                                 setBody(narmesteLederRelasjon)
-                                bearerAuth(createMockToken(narmesteLederRelasjon.orgNumber))
+                                bearerAuth(createMockToken(narmesteLederRelasjon.orgNumber.value))
                             }
 
                         // Assert
@@ -219,7 +221,7 @@ class LinenmanagerApiV1Test :
                         texasHttpClientMock.defaultMocks(
                             consumer =
                             DefaultOrganization.copy(
-                                ID = "0192:${narmesteLederRelasjon.orgNumber}",
+                                ID = "0192:${narmesteLederRelasjon.orgNumber.value}",
                             ),
                             scope = MASKINPORTEN_NL_SCOPE,
                         )
@@ -232,6 +234,42 @@ class LinenmanagerApiV1Test :
                             }
 
                         // Assert
+                        response.status shouldBe HttpStatusCode.BadRequest
+                        response.body<ApiError>().type shouldBe ErrorType.INVALID_FORMAT
+                        coVerify { narmestelederKafkaServiceSpy wasNot Called }
+                    }
+                }
+
+                it("should return 400 Bad Request for invalid organization number in request body") {
+                    withTestApplication {
+                        texasHttpClientMock.defaultMocks(
+                            consumer = DefaultOrganization.copy(
+                                ID = "0192:${narmesteLederRelasjon.orgNumber.value}",
+                            ),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+
+                        val response =
+                            client.post("/api/v1/linemanager") {
+                                contentType(ContentType.Application.Json)
+                                setBody(
+                                    """
+                                    {
+                                      "employeeIdentificationNumber": "12345678901",
+                                      "lastName": "Hansen",
+                                      "orgNumber": "12345678",
+                                      "manager": {
+                                        "nationalIdentificationNumber": "10987654321",
+                                        "lastName": "Jensen",
+                                        "mobile": "+4790000000",
+                                        "email": "leder@example.com"
+                                      }
+                                    }
+                                    """.trimIndent(),
+                                )
+                                bearerAuth(createMockToken(maskinportenIdToOrgnumber(DefaultOrganization.ID)))
+                            }
+
                         response.status shouldBe HttpStatusCode.BadRequest
                         response.body<ApiError>().type shouldBe ErrorType.INVALID_FORMAT
                         coVerify { narmestelederKafkaServiceSpy wasNot Called }
@@ -262,7 +300,7 @@ class LinenmanagerApiV1Test :
                         texasHttpClientMock.defaultMocks(
                             consumer =
                             DefaultOrganization.copy(
-                                ID = "0192:${narmesteLederRelasjon.orgNumber}",
+                                ID = "0192:${narmesteLederRelasjon.orgNumber.value}",
                             ),
                             scope = "invalid-scope",
                         )
@@ -305,7 +343,7 @@ class LinenmanagerApiV1Test :
                         // Arrange
                         pdlService.prepareGetPersonResponse(narmesteLederRelasjon.manager)
                         pdlService.prepareGetPersonResponse(
-                            narmesteLederRelasjon.employeeIdentificationNumber,
+                            narmesteLederRelasjon.employeeIdentificationNumber.value,
                             narmesteLederRelasjon.lastName,
                         )
                         val callerPid = "11223344556"
@@ -314,14 +352,14 @@ class LinenmanagerApiV1Test :
                             pid = callerPid,
                         )
                         fakeAltinnTilgangerClient.accessPolicy.clear()
-                        fakeAltinnTilgangerClient.addAccess(callerPid, narmesteLederRelasjon.orgNumber)
+                        fakeAltinnTilgangerClient.addAccess(callerPid, narmesteLederRelasjon.orgNumber.value)
                         fakeAaregClient.arbeidsForholdForIdent.put(
-                            narmesteLederRelasjon.employeeIdentificationNumber,
-                            listOf(narmesteLederRelasjon.orgNumber to narmesteLederRelasjon.orgNumber),
+                            narmesteLederRelasjon.employeeIdentificationNumber.value,
+                            listOf(narmesteLederRelasjon.orgNumber.value to narmesteLederRelasjon.orgNumber.value),
                         )
                         fakeAaregClient.arbeidsForholdForIdent.put(
-                            narmesteLederRelasjon.manager.nationalIdentificationNumber,
-                            listOf(narmesteLederRelasjon.orgNumber to narmesteLederRelasjon.orgNumber),
+                            narmesteLederRelasjon.manager.nationalIdentificationNumber.value,
+                            listOf(narmesteLederRelasjon.orgNumber.value to narmesteLederRelasjon.orgNumber.value),
                         )
                         // Act
                         val response =
@@ -377,7 +415,7 @@ class LinenmanagerApiV1Test :
                             acr = "Level3",
                             pid = callerPid,
                         )
-                        fakeAltinnTilgangerClient.addAccess(callerPid, narmesteLederRelasjon.orgNumber)
+                        fakeAltinnTilgangerClient.addAccess(callerPid, narmesteLederRelasjon.orgNumber.value)
                         // Act
                         val response =
                             client.post("/api/v1/linemanager") {
@@ -401,18 +439,18 @@ class LinenmanagerApiV1Test :
                     texasHttpClientMock.defaultMocks(
                         systemBrukerOrganisasjon =
                         DefaultOrganization.copy(
-                            ID = "0192:${narmesteLederAvkreft.orgNumber}",
+                            ID = "0192:${narmesteLederAvkreft.orgNumber.value}",
                         ),
                         scope = MASKINPORTEN_NL_SCOPE,
                     )
                     pdlService.prepareGetPersonResponse(
-                        narmesteLederAvkreft.employeeIdentificationNumber,
+                        narmesteLederAvkreft.employeeIdentificationNumber.value,
                         narmesteLederAvkreft.lastName,
                     )
                     val narmesteLederAvkreft = narmesteLederAvkreft
                     fakeAaregClient.arbeidsForholdForIdent.clear()
-                    fakeAaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber] =
-                        listOf(narmesteLederAvkreft.orgNumber to narmesteLederRelasjon.orgNumber)
+                    fakeAaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber.value] =
+                        listOf(narmesteLederAvkreft.orgNumber.value to narmesteLederRelasjon.orgNumber.value)
                     // Act
                     val response =
                         client.post("$API_V1_PATH/$REVOKE_PATH") {
@@ -445,18 +483,18 @@ class LinenmanagerApiV1Test :
                     texasHttpClientMock.defaultMocks(
                         systemBrukerOrganisasjon =
                         DefaultOrganization.copy(
-                            ID = "0192:${narmesteLederAvkreft.orgNumber}",
+                            ID = "0192:${narmesteLederAvkreft.orgNumber.value}",
                         ),
                         scope = MASKINPORTEN_NL_SCOPE,
                     )
                     pdlService.prepareGetPersonResponse(
-                        narmesteLederAvkreft.employeeIdentificationNumber,
+                        narmesteLederAvkreft.employeeIdentificationNumber.value,
                         narmesteLederAvkreft.lastName.reversed(),
                     )
                     val narmesteLederAvkreft = narmesteLederAvkreft
                     fakeAaregClient.arbeidsForholdForIdent.clear()
-                    fakeAaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber] =
-                        listOf(narmesteLederAvkreft.orgNumber to narmesteLederRelasjon.orgNumber)
+                    fakeAaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber.value] =
+                        listOf(narmesteLederAvkreft.orgNumber.value to narmesteLederRelasjon.orgNumber.value)
                     // Act
                     val response =
                         client.post("$API_V1_PATH/$REVOKE_PATH") {
@@ -492,7 +530,7 @@ class LinenmanagerApiV1Test :
                     val narmesteLederAvkreft = linemanagerRevoke()
                     texasHttpClientMock.defaultMocks(
                         systemBrukerOrganisasjon = DefaultOrganization.copy(
-                            ID = "0192:${narmesteLederAvkreft.orgNumber}",
+                            ID = "0192:${narmesteLederAvkreft.orgNumber.value}",
                         ),
                         scope = MASKINPORTEN_NL_SCOPE,
                     )
@@ -523,7 +561,7 @@ class LinenmanagerApiV1Test :
                     texasHttpClientMock.defaultMocks(
                         consumer =
                         DefaultOrganization.copy(
-                            ID = "0192:${narmesteLederRelasjon.orgNumber}",
+                            ID = "0192:${narmesteLederRelasjon.orgNumber.value}",
                         ),
                         scope = MASKINPORTEN_NL_SCOPE,
                     )
@@ -543,13 +581,13 @@ class LinenmanagerApiV1Test :
             }
         }
         describe("/linemanager/requirement endpoints") {
-            val sykmeldtFnr = narmesteLederRelasjon.employeeIdentificationNumber
-            val lederFnr = narmesteLederRelasjon.manager.nationalIdentificationNumber
-            val orgnummer = narmesteLederRelasjon.orgNumber
+            val sykmeldtFnr = narmesteLederRelasjon.employeeIdentificationNumber.value
+            val lederFnr = narmesteLederRelasjon.manager.nationalIdentificationNumber.value
+            val orgnummer = narmesteLederRelasjon.orgNumber.value
 
             fun Linemanager.toNlBehovWrite(): LinemanagerRequirementWrite = LinemanagerRequirementWrite(
-                employeeIdentificationNumber = sykmeldtFnr,
-                orgNumber = orgNumber,
+                employeeIdentificationNumber = PersonalIdentificationNumber(sykmeldtFnr),
+                orgNumber = OrganizationNumber(orgNumber.value),
                 managerIdentificationNumber = manager.nationalIdentificationNumber,
                 behovReason = BehovReason.DEAKTIVERT_LEDER,
                 revokedLinemanagerId = UUID.randomUUID(),
@@ -579,8 +617,8 @@ class LinenmanagerApiV1Test :
                         response.status shouldBe HttpStatusCode.OK
                         val body = response.body<LinemanagerRequirementRead>()
                         body.id shouldBe requirementId
-                        body.orgNumber shouldBe orgnummer
-                        body.employeeIdentificationNumber shouldBe sykmeldtFnr
+                        body.orgNumber.value shouldBe orgnummer
+                        body.employeeIdentificationNumber.value shouldBe sykmeldtFnr
                     }
                 }
 
@@ -606,8 +644,8 @@ class LinenmanagerApiV1Test :
                             systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:000000000"), // mismatch org
                             scope = MASKINPORTEN_NL_SCOPE,
                         )
-                        fakeEregClient.organisasjoner[narmesteLederRelasjon.orgNumber] = Organisasjon(
-                            organisasjonsnummer = narmesteLederRelasjon.orgNumber,
+                        fakeEregClient.organisasjoner[narmesteLederRelasjon.orgNumber.value] = Organisasjon(
+                            organisasjonsnummer = narmesteLederRelasjon.orgNumber.value,
                             inngaarIJuridiskEnheter = emptyList()
                         )
                         val requirementId = seedLinemanagerRequirement()
@@ -633,13 +671,16 @@ class LinenmanagerApiV1Test :
                         val manager =
                             manager().copy(
                                 nationalIdentificationNumber =
-                                narmesteLederRelasjon
-                                    .manager
-                                    .nationalIdentificationNumber
-                                    .reversed(),
+                                PersonalIdentificationNumber(
+                                    narmesteLederRelasjon
+                                        .manager
+                                        .nationalIdentificationNumber
+                                        .value
+                                        .reversed(),
+                                ),
                             )
                         pdlService.prepareGetPersonResponse(manager)
-                        fakeAaregClient.arbeidsForholdForIdent[manager.nationalIdentificationNumber] =
+                        fakeAaregClient.arbeidsForholdForIdent[manager.nationalIdentificationNumber.value] =
                             listOf(orgnummer to orgnummer)
 
                         val response =
@@ -652,9 +693,9 @@ class LinenmanagerApiV1Test :
                         coVerify(exactly = 1) {
                             narmestelederKafkaServiceSpy.sendNarmesteLederRelasjon(
                                 match { linemanager ->
-                                    linemanager.employeeIdentificationNumber == sykmeldtFnr &&
-                                        linemanager.orgNumber == orgnummer &&
-                                        linemanager.manager.nationalIdentificationNumber == manager.nationalIdentificationNumber
+                                    linemanager.employeeIdentificationNumber.value == sykmeldtFnr &&
+                                        linemanager.orgNumber.value == orgnummer &&
+                                        linemanager.manager.nationalIdentificationNumber.value == manager.nationalIdentificationNumber.value
                                 },
                                 any(),
                                 any(),
@@ -729,7 +770,7 @@ class LinenmanagerApiV1Test :
                 it("GET /requirement should use provided query parameters to fetch results") {
                     withTestApplication {
                         texasHttpClientMock.defaultMocks(
-                            systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:${narmesteLederRelasjon.orgNumber}"),
+                            systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:${narmesteLederRelasjon.orgNumber.value}"),
                             scope = MASKINPORTEN_NL_SCOPE,
                         )
                         val requirementId = seedLinemanagerRequirement()
@@ -737,11 +778,11 @@ class LinenmanagerApiV1Test :
                         val pageSize = 10
                         val response =
                             client.get(
-                                "$API_V1_PATH/$RECUIREMENT_PATH?orgNumber=${requirement.orgNumber}&createdAfter=${
+                                "$API_V1_PATH/$RECUIREMENT_PATH?orgNumber=${requirement.orgNumber.value}&createdAfter=${
                                     Instant.now().minusSeconds(60)
                                 }&pageSize=$pageSize",
                             ) {
-                                bearerAuth(createMockToken(narmesteLederRelasjon.orgNumber))
+                                bearerAuth(createMockToken(narmesteLederRelasjon.orgNumber.value))
                             }
                         response.status shouldBe HttpStatusCode.OK
                         val body = response.body<LinemanagerRequirementCollection>()
@@ -751,7 +792,7 @@ class LinenmanagerApiV1Test :
 
                         coVerify(exactly = 1) {
                             fakeRepo.findBehovByParameters(
-                                orgNumber = requirement.orgNumber,
+                                orgNumber = requirement.orgNumber.value,
                                 createdAfter = any(),
                                 status =
                                 listOf(
@@ -761,6 +802,44 @@ class LinenmanagerApiV1Test :
                                 limit = pageSize + 1, // +1 to check if there is more pages
                             )
                         }
+                    }
+                }
+
+                it("GET /requirement should return 400 for invalid orgNumber query parameter") {
+                    withTestApplication {
+                        texasHttpClientMock.defaultMocks(
+                            systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:${narmesteLederRelasjon.orgNumber.value}"),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+
+                        val response =
+                            client.get(
+                                "$API_V1_PATH/$RECUIREMENT_PATH?orgNumber=12345678&createdAfter=${Instant.now().minusSeconds(60)}",
+                            ) {
+                                bearerAuth(createMockToken(narmesteLederRelasjon.orgNumber.value))
+                            }
+
+                        response.status shouldBe HttpStatusCode.BadRequest
+                        response.body<ApiError>().type shouldBe ErrorType.INVALID_FORMAT
+                    }
+                }
+
+                it("GET /requirement should return 400 for non-digit orgNumber query parameter") {
+                    withTestApplication {
+                        texasHttpClientMock.defaultMocks(
+                            systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:${narmesteLederRelasjon.orgNumber.value}"),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+
+                        val response =
+                            client.get(
+                                "$API_V1_PATH/$RECUIREMENT_PATH?orgNumber=12345678a&createdAfter=${Instant.now().minusSeconds(60)}",
+                            ) {
+                                bearerAuth(createMockToken(narmesteLederRelasjon.orgNumber.value))
+                            }
+
+                        response.status shouldBe HttpStatusCode.BadRequest
+                        response.body<ApiError>().type shouldBe ErrorType.INVALID_FORMAT
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/domain/OrganizationNumberTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/domain/OrganizationNumberTest.kt
@@ -1,0 +1,60 @@
+package no.nav.syfo.narmesteleder.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class OrganizationNumberTest :
+    DescribeSpec({
+        describe("OrganizationNumber") {
+            it("should accept valid 9-digit number") {
+                val orgNr = OrganizationNumber("123456789")
+                orgNr.value shouldBe "123456789"
+            }
+
+            it("should reject number with fewer than 9 digits") {
+                shouldThrow<IllegalArgumentException> {
+                    OrganizationNumber("12345678")
+                }
+            }
+
+            it("should reject number with more than 9 digits") {
+                shouldThrow<IllegalArgumentException> {
+                    OrganizationNumber("1234567890")
+                }
+            }
+
+            it("should reject non-digit characters") {
+                shouldThrow<IllegalArgumentException> {
+                    OrganizationNumber("12345678a")
+                }
+            }
+
+            it("should reject empty string") {
+                shouldThrow<IllegalArgumentException> {
+                    OrganizationNumber("")
+                }
+            }
+
+            it("should reject string with spaces") {
+                shouldThrow<IllegalArgumentException> {
+                    OrganizationNumber("123 56789")
+                }
+            }
+        }
+
+        describe("OrganizationNumber.parse") {
+            it("should return success for valid input") {
+                val result = OrganizationNumber.parse("123456789")
+                result.isSuccess shouldBe true
+                result.getOrThrow().value shouldBe "123456789"
+            }
+
+            it("should return failure for invalid input") {
+                val result = OrganizationNumber.parse("12345")
+                result.isFailure shouldBe true
+                result.exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/domain/OrganizationNumberTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/domain/OrganizationNumberTest.kt
@@ -7,40 +7,38 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 
 class OrganizationNumberTest :
     DescribeSpec({
-        describe("OrganizationNumber") {
-            it("should accept valid 9-digit number") {
-                val orgNr = OrganizationNumber("123456789")
-                orgNr.value shouldBe "123456789"
-            }
+        it("should accept valid 9-digit number") {
+            val orgNr = OrganizationNumber("123456789")
+            orgNr.value shouldBe "123456789"
+        }
 
-            it("should reject number with fewer than 9 digits") {
-                shouldThrow<IllegalArgumentException> {
-                    OrganizationNumber("12345678")
-                }
+        it("should reject number with fewer than 9 digits") {
+            shouldThrow<IllegalArgumentException> {
+                OrganizationNumber("12345678")
             }
+        }
 
-            it("should reject number with more than 9 digits") {
-                shouldThrow<IllegalArgumentException> {
-                    OrganizationNumber("1234567890")
-                }
+        it("should reject number with more than 9 digits") {
+            shouldThrow<IllegalArgumentException> {
+                OrganizationNumber("1234567890")
             }
+        }
 
-            it("should reject non-digit characters") {
-                shouldThrow<IllegalArgumentException> {
-                    OrganizationNumber("12345678a")
-                }
+        it("should reject non-digit characters") {
+            shouldThrow<IllegalArgumentException> {
+                OrganizationNumber("12345678a")
             }
+        }
 
-            it("should reject empty string") {
-                shouldThrow<IllegalArgumentException> {
-                    OrganizationNumber("")
-                }
+        it("should reject empty string") {
+            shouldThrow<IllegalArgumentException> {
+                OrganizationNumber("")
             }
+        }
 
-            it("should reject string with spaces") {
-                shouldThrow<IllegalArgumentException> {
-                    OrganizationNumber("123 56789")
-                }
+        it("should reject string with spaces") {
+            shouldThrow<IllegalArgumentException> {
+                OrganizationNumber("123 56789")
             }
         }
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/domain/PersonalIdentificationNumberTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/domain/PersonalIdentificationNumberTest.kt
@@ -1,0 +1,65 @@
+package no.nav.syfo.narmesteleder.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class PersonalIdentificationNumberTest :
+    DescribeSpec({
+        describe("PersonalIdentificationNumber") {
+            it("should accept valid 11-digit number") {
+                val pin = PersonalIdentificationNumber("12345678901")
+                pin.value shouldBe "12345678901"
+            }
+
+            it("should accept D-number (first digit + 4)") {
+                val dNumber = PersonalIdentificationNumber("52345678901")
+                dNumber.value shouldBe "52345678901"
+            }
+
+            it("should reject number with fewer than 11 digits") {
+                shouldThrow<IllegalArgumentException> {
+                    PersonalIdentificationNumber("1234567890")
+                }
+            }
+
+            it("should reject number with more than 11 digits") {
+                shouldThrow<IllegalArgumentException> {
+                    PersonalIdentificationNumber("123456789012")
+                }
+            }
+
+            it("should reject non-digit characters") {
+                shouldThrow<IllegalArgumentException> {
+                    PersonalIdentificationNumber("1234567890a")
+                }
+            }
+
+            it("should reject empty string") {
+                shouldThrow<IllegalArgumentException> {
+                    PersonalIdentificationNumber("")
+                }
+            }
+
+            it("should reject string with spaces") {
+                shouldThrow<IllegalArgumentException> {
+                    PersonalIdentificationNumber("123 5678901")
+                }
+            }
+        }
+
+        describe("PersonalIdentificationNumber.parse") {
+            it("should return success for valid input") {
+                val result = PersonalIdentificationNumber.parse("12345678901")
+                result.isSuccess shouldBe true
+                result.getOrThrow().value shouldBe "12345678901"
+            }
+
+            it("should return failure for invalid input") {
+                val result = PersonalIdentificationNumber.parse("123")
+                result.isFailure shouldBe true
+                result.exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/domain/PersonalIdentificationNumberTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/domain/PersonalIdentificationNumberTest.kt
@@ -7,45 +7,43 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 
 class PersonalIdentificationNumberTest :
     DescribeSpec({
-        describe("PersonalIdentificationNumber") {
-            it("should accept valid 11-digit number") {
-                val pin = PersonalIdentificationNumber("12345678901")
-                pin.value shouldBe "12345678901"
-            }
+        it("should accept valid 11-digit number") {
+            val pin = PersonalIdentificationNumber("12345678901")
+            pin.value shouldBe "12345678901"
+        }
 
-            it("should accept D-number (first digit + 4)") {
-                val dNumber = PersonalIdentificationNumber("52345678901")
-                dNumber.value shouldBe "52345678901"
-            }
+        it("should accept D-number (first digit + 4)") {
+            val dNumber = PersonalIdentificationNumber("52345678901")
+            dNumber.value shouldBe "52345678901"
+        }
 
-            it("should reject number with fewer than 11 digits") {
-                shouldThrow<IllegalArgumentException> {
-                    PersonalIdentificationNumber("1234567890")
-                }
+        it("should reject number with fewer than 11 digits") {
+            shouldThrow<IllegalArgumentException> {
+                PersonalIdentificationNumber("1234567890")
             }
+        }
 
-            it("should reject number with more than 11 digits") {
-                shouldThrow<IllegalArgumentException> {
-                    PersonalIdentificationNumber("123456789012")
-                }
+        it("should reject number with more than 11 digits") {
+            shouldThrow<IllegalArgumentException> {
+                PersonalIdentificationNumber("123456789012")
             }
+        }
 
-            it("should reject non-digit characters") {
-                shouldThrow<IllegalArgumentException> {
-                    PersonalIdentificationNumber("1234567890a")
-                }
+        it("should reject non-digit characters") {
+            shouldThrow<IllegalArgumentException> {
+                PersonalIdentificationNumber("1234567890a")
             }
+        }
 
-            it("should reject empty string") {
-                shouldThrow<IllegalArgumentException> {
-                    PersonalIdentificationNumber("")
-                }
+        it("should reject empty string") {
+            shouldThrow<IllegalArgumentException> {
+                PersonalIdentificationNumber("")
             }
+        }
 
-            it("should reject string with spaces") {
-                shouldThrow<IllegalArgumentException> {
-                    PersonalIdentificationNumber("123 5678901")
-                }
+        it("should reject string with spaces") {
+            shouldThrow<IllegalArgumentException> {
+                PersonalIdentificationNumber("123 5678901")
             }
         }
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/kafka/SykemeldingNLKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/kafka/SykemeldingNLKafkaProducerTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import linemanager
 import linemanagerRevoke
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.kafka.model.INlResponseKafkaMessage
 import no.nav.syfo.narmesteleder.kafka.model.NlAvbruddResponseKafkaMessage
 import no.nav.syfo.narmesteleder.kafka.model.NlRelationResponseKafkaMessage
@@ -42,7 +43,7 @@ class SykemeldingNLKafkaProducerTest :
                 // Arrange
                 val relasjon = linemanager()
                 val linemanagerPerson = Person(
-                    nationalIdentificationNumber = faker.numerify("###########"),
+                    nationalIdentificationNumber = PersonalIdentificationNumber(faker.numerify("###########")),
                     name =
                     Navn(faker.name().firstName(), null, faker.name().lastName())
                 )
@@ -57,7 +58,7 @@ class SykemeldingNLKafkaProducerTest :
                 coEvery { kafkaProducerMock.send(any<ProducerRecord<String, INlResponseKafkaMessage>>()) } returns futureMock
 
                 val sykmeldingNL = NlResponse(
-                    orgnummer = relasjon.orgNumber,
+                    orgnummer = relasjon.orgNumber.value,
                     leder = relasjon.manager.toLeder(linemanagerPerson),
                     sykmeldt = Sykmeldt.from(sykmeldtPerson),
                     utbetalesLonn = null,
@@ -100,8 +101,8 @@ class SykemeldingNLKafkaProducerTest :
                             it.shouldBeInstanceOf<ProducerRecord<String, NlAvbruddResponseKafkaMessage>>()
                             it.value().kafkaMetadata.source shouldBe NlResponseSource.LPS.source
                             it.value().nlAvbrutt shouldNotBe null
-                            it.value().nlAvbrutt.orgnummer shouldBe avbryt.orgNumber
-                            it.value().nlAvbrutt.sykmeldtFnr shouldBe avbryt.employeeIdentificationNumber
+                            it.value().nlAvbrutt.orgnummer shouldBe avbryt.orgNumber.value
+                            it.value().nlAvbrutt.sykmeldtFnr shouldBe avbryt.employeeIdentificationNumber.value
                             it.value().nlAvbrutt.aktivTom shouldBeAfter now
                         }
                     )

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/kafka/model/NLBehovLeesahHandlerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/kafka/model/NLBehovLeesahHandlerTest.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.narmesteleder.db.NarmestelederBehovEntity
 import no.nav.syfo.narmesteleder.domain.BehovReason
 import no.nav.syfo.narmesteleder.domain.BehovStatus
 import no.nav.syfo.narmesteleder.domain.Manager
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -28,7 +29,7 @@ class NLBehovLeesahHandlerTest :
         val arbeidsforholdManagerAareg = fakeAaregClient.arbeidsForholdForIdent[defaultManagerFnr]!!.first()
 
         val defaultManager = Manager(
-            nationalIdentificationNumber = defaultManagerFnr,
+            nationalIdentificationNumber = PersonalIdentificationNumber(defaultManagerFnr),
             lastName = "ManagerLastName",
             mobile = "99999999",
             email = "mail@manager.no",

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/kafka/model/NlResponseSourceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/kafka/model/NlResponseSourceTest.kt
@@ -27,7 +27,7 @@ class NlResponseSourceTest :
                 // Arrange
 
                 val linemanager = linemanager()
-                val principal = UserPrincipal(linemanager.employeeIdentificationNumber, "token")
+                val principal = UserPrincipal(linemanager.employeeIdentificationNumber.value, "token")
 
                 // Act
                 val source = NlResponseSource.getSourceFrom(principal, linemanager)
@@ -53,7 +53,7 @@ class NlResponseSourceTest :
                 // Arrange
 
                 val linemanager = linemanagerRevoke()
-                val principal = UserPrincipal(linemanager.employeeIdentificationNumber, "token")
+                val principal = UserPrincipal(linemanager.employeeIdentificationNumber.value, "token")
 
                 // Act
                 val source = NlResponseSource.getSourceFrom(principal, linemanager)

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederServiceTest.kt
@@ -21,6 +21,8 @@ import no.nav.syfo.narmesteleder.db.NarmestelederBehovEntity
 import no.nav.syfo.narmesteleder.domain.BehovReason
 import no.nav.syfo.narmesteleder.domain.BehovStatus
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementWrite
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.exception.HovedenhetNotFoundException
 import no.nav.syfo.narmesteleder.exception.LinemanagerRequirementNotFoundException
 import no.nav.syfo.pdl.PdlService
@@ -56,9 +58,9 @@ class NarmestelederServiceTest :
                 val underenhetOrg = "123456789"
                 val hovedenhetOrg = "987654321"
                 val write = LinemanagerRequirementWrite(
-                    employeeIdentificationNumber = sykmeldtFnr,
-                    orgNumber = underenhetOrg,
-                    managerIdentificationNumber = "01987654321",
+                    employeeIdentificationNumber = PersonalIdentificationNumber(sykmeldtFnr),
+                    orgNumber = OrganizationNumber(underenhetOrg),
+                    managerIdentificationNumber = PersonalIdentificationNumber("01987654321"),
                     behovReason = BehovReason.DEAKTIVERT_LEDER,
                     revokedLinemanagerId = UUID.randomUUID(),
                 )
@@ -82,8 +84,8 @@ class NarmestelederServiceTest :
                 }
                 coEvery {
                     dinesykmeldteService.getIsActiveSykmelding(
-                        eq(write.employeeIdentificationNumber),
-                        eq(write.orgNumber)
+                        eq(write.employeeIdentificationNumber.value),
+                        eq(write.orgNumber.value)
                     )
                 } returns true
 
@@ -95,14 +97,14 @@ class NarmestelederServiceTest :
 
                 // Assert
                 coVerify(exactly = 1) { nlDb.insertNlBehov(any()) }
-                coVerify(exactly = 1) { aaregService.findArbeidsforholdByPersonIdent(eq(write.employeeIdentificationNumber)) }
+                coVerify(exactly = 1) { aaregService.findArbeidsforholdByPersonIdent(eq(write.employeeIdentificationNumber.value)) }
 
                 captured.isCaptured shouldBe true
                 val entity = captured.captured
                 entity.sykmeldtFnr shouldBe sykmeldtFnr
                 entity.orgnummer shouldBe underenhetOrg
                 entity.hovedenhetOrgnummer shouldBe hovedenhetOrg
-                entity.narmestelederFnr shouldBe write.managerIdentificationNumber
+                entity.narmestelederFnr shouldBe write.managerIdentificationNumber?.value
                 entity.behovReason shouldBe write.behovReason
                 entity.behovStatus shouldBe BehovStatus.BEHOV_CREATED
             }
@@ -112,9 +114,9 @@ class NarmestelederServiceTest :
                 val sykmeldtFnr = "12345678910"
                 val underenhetOrg = "123456789"
                 val write = LinemanagerRequirementWrite(
-                    employeeIdentificationNumber = sykmeldtFnr,
-                    orgNumber = underenhetOrg,
-                    managerIdentificationNumber = "01987654321",
+                    employeeIdentificationNumber = PersonalIdentificationNumber(sykmeldtFnr),
+                    orgNumber = OrganizationNumber(underenhetOrg),
+                    managerIdentificationNumber = PersonalIdentificationNumber("01987654321"),
                     behovReason = BehovReason.DEAKTIVERT_LEDER,
                     revokedLinemanagerId = UUID.randomUUID(),
                 )
@@ -146,17 +148,17 @@ class NarmestelederServiceTest :
                 val sykmeldtFnr = "12345678910"
                 val underenhetOrg = "123456789"
                 val write = LinemanagerRequirementWrite(
-                    employeeIdentificationNumber = sykmeldtFnr,
-                    orgNumber = underenhetOrg,
-                    managerIdentificationNumber = "01987654321",
+                    employeeIdentificationNumber = PersonalIdentificationNumber(sykmeldtFnr),
+                    orgNumber = OrganizationNumber(underenhetOrg),
+                    managerIdentificationNumber = PersonalIdentificationNumber("01987654321"),
                     behovReason = BehovReason.DEAKTIVERT_LEDER,
                     revokedLinemanagerId = UUID.randomUUID(),
                 )
                 coEvery { aaregService.findArbeidsforholdByPersonIdent(sykmeldtFnr) } returns emptyList()
                 coEvery {
                     dinesykmeldteService.getIsActiveSykmelding(
-                        eq(write.employeeIdentificationNumber),
-                        eq(write.orgNumber)
+                        eq(write.employeeIdentificationNumber.value),
+                        eq(write.orgNumber.value)
                     )
                 } returns true
 
@@ -169,7 +171,7 @@ class NarmestelederServiceTest :
                 }
 
                 // Assert
-                coVerify(exactly = 1) { aaregService.findArbeidsforholdByPersonIdent(eq(write.employeeIdentificationNumber)) }
+                coVerify(exactly = 1) { aaregService.findArbeidsforholdByPersonIdent(eq(write.employeeIdentificationNumber.value)) }
                 coVerify(exactly = 1) {
                     nlDb.insertNlBehov(
                         withArg {
@@ -185,9 +187,9 @@ class NarmestelederServiceTest :
                 val sykmeldtFnr = "12345678910"
                 val underenhetOrg = "123456789"
                 val write = LinemanagerRequirementWrite(
-                    employeeIdentificationNumber = sykmeldtFnr,
-                    orgNumber = underenhetOrg,
-                    managerIdentificationNumber = "01987654321",
+                    employeeIdentificationNumber = PersonalIdentificationNumber(sykmeldtFnr),
+                    orgNumber = OrganizationNumber(underenhetOrg),
+                    managerIdentificationNumber = PersonalIdentificationNumber("01987654321"),
                     behovReason = BehovReason.DEAKTIVERT_LEDER,
                     revokedLinemanagerId = UUID.randomUUID(),
                 )
@@ -201,8 +203,8 @@ class NarmestelederServiceTest :
                 )
                 coEvery {
                     dinesykmeldteService.getIsActiveSykmelding(
-                        eq(write.employeeIdentificationNumber),
-                        eq(write.orgNumber)
+                        eq(write.employeeIdentificationNumber.value),
+                        eq(write.orgNumber.value)
                     )
                 } returns true
 
@@ -215,7 +217,7 @@ class NarmestelederServiceTest :
                 }
 
                 // Assert
-                coVerify(exactly = 1) { aaregService.findArbeidsforholdByPersonIdent(eq(write.employeeIdentificationNumber)) }
+                coVerify(exactly = 1) { aaregService.findArbeidsforholdByPersonIdent(eq(write.employeeIdentificationNumber.value)) }
                 coVerify(exactly = 1) {
                     nlDb.insertNlBehov(
                         withArg {
@@ -231,9 +233,9 @@ class NarmestelederServiceTest :
                 val sykmeldtFnr = "12345678910"
                 val underenhetOrg = "123456789"
                 val write = LinemanagerRequirementWrite(
-                    employeeIdentificationNumber = sykmeldtFnr,
-                    orgNumber = underenhetOrg,
-                    managerIdentificationNumber = "01987654321",
+                    employeeIdentificationNumber = PersonalIdentificationNumber(sykmeldtFnr),
+                    orgNumber = OrganizationNumber(underenhetOrg),
+                    managerIdentificationNumber = PersonalIdentificationNumber("01987654321"),
                     behovReason = BehovReason.DEAKTIVERT_LEDER,
                     revokedLinemanagerId = UUID.randomUUID(),
                 )
@@ -246,8 +248,8 @@ class NarmestelederServiceTest :
 
                 coEvery {
                     dinesykmeldteService.getIsActiveSykmelding(
-                        eq(write.employeeIdentificationNumber),
-                        eq(write.orgNumber)
+                        eq(write.employeeIdentificationNumber.value),
+                        eq(write.orgNumber.value)
                     )
                 } returns true
 
@@ -280,17 +282,17 @@ class NarmestelederServiceTest :
                 val sykmeldtFnr = "12345678910"
                 val underenhetOrg = "123456789"
                 val write = LinemanagerRequirementWrite(
-                    employeeIdentificationNumber = sykmeldtFnr,
-                    orgNumber = underenhetOrg,
-                    managerIdentificationNumber = "01987654321",
+                    employeeIdentificationNumber = PersonalIdentificationNumber(sykmeldtFnr),
+                    orgNumber = OrganizationNumber(underenhetOrg),
+                    managerIdentificationNumber = PersonalIdentificationNumber("01987654321"),
                     behovReason = BehovReason.DEAKTIVERT_LEDER,
                     revokedLinemanagerId = UUID.randomUUID(),
                 )
 
                 coEvery {
                     dinesykmeldteService.getIsActiveSykmelding(
-                        eq(write.employeeIdentificationNumber),
-                        eq(write.orgNumber)
+                        eq(write.employeeIdentificationNumber.value),
+                        eq(write.orgNumber.value)
                     )
                 } returns false
 
@@ -327,10 +329,10 @@ class NarmestelederServiceTest :
                 coVerify(exactly = 0) { pdlService.getPersonFor(any()) }
                 val read = service().getLinemanagerRequirementReadById(id)
                 read.id shouldBe id
-                read.orgNumber shouldBe entity.orgnummer
-                read.mainOrgNumber shouldBe entity.hovedenhetOrgnummer
-                read.employeeIdentificationNumber shouldBe entity.sykmeldtFnr
-                read.managerIdentificationNumber shouldBe entity.narmestelederFnr
+                read.orgNumber.value shouldBe entity.orgnummer
+                read.mainOrgNumber.value shouldBe entity.hovedenhetOrgnummer
+                read.employeeIdentificationNumber.value shouldBe entity.sykmeldtFnr
+                read.managerIdentificationNumber?.value shouldBe entity.narmestelederFnr
                 read.name.firstName shouldBe entity.fornavn
                 read.name.middleName shouldBe entity.mellomnavn
                 read.name.lastName shouldBe entity.etternavn
@@ -362,7 +364,7 @@ class NarmestelederServiceTest :
                 coEvery { nlDb.findBehovById(id) } returns entity
                 coEvery { pdlService.getPersonFor(entity.sykmeldtFnr) } returns Person(
                     name = navn,
-                    nationalIdentificationNumber = entity.sykmeldtFnr
+                    nationalIdentificationNumber = PersonalIdentificationNumber(entity.sykmeldtFnr)
                 )
                 // Act
                 val read = service().getLinemanagerRequirementReadById(id)
@@ -371,10 +373,10 @@ class NarmestelederServiceTest :
                 coVerify(exactly = 1) { pdlService.getPersonFor(eq(entity.sykmeldtFnr)) }
                 coVerify(exactly = 1) { nlDb.updateNlBehov(any()) }
                 read.id shouldBe id
-                read.orgNumber shouldBe entity.orgnummer
-                read.mainOrgNumber shouldBe entity.hovedenhetOrgnummer
-                read.employeeIdentificationNumber shouldBe entity.sykmeldtFnr
-                read.managerIdentificationNumber shouldBe entity.narmestelederFnr
+                read.orgNumber.value shouldBe entity.orgnummer
+                read.mainOrgNumber.value shouldBe entity.hovedenhetOrgnummer
+                read.employeeIdentificationNumber.value shouldBe entity.sykmeldtFnr
+                read.managerIdentificationNumber?.value shouldBe entity.narmestelederFnr
                 read.name.firstName shouldBe navn.fornavn
                 read.name.lastName shouldBe navn.etternavn
                 read.name.middleName shouldBe navn.mellomnavn

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
@@ -32,6 +32,8 @@ import no.nav.syfo.ereg.EregService
 import no.nav.syfo.ereg.client.FakeEregClient
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerRevoke
+import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.service.validators.PrincipalAccessValidator
 import no.nav.syfo.narmesteleder.service.validators.SickLeaveValidator
 import no.nav.syfo.pdl.PdlService
@@ -83,12 +85,12 @@ class ValidationServiceTest :
             principal: UserPrincipal,
         ) {
             altinnTilgangerClient.accessPolicy.clear()
-            altinnTilgangerClient.addAccess(principal.ident, linemanager.orgNumber)
-            aaregClient.arbeidsForholdForIdent[linemanager.manager.nationalIdentificationNumber] =
-                listOf(linemanager.orgNumber to "hovedenhet")
-            aaregClient.arbeidsForholdForIdent[linemanager.employeeIdentificationNumber] =
-                listOf(linemanager.orgNumber to "hovedenhet")
-            pdlService.prepareGetPersonResponse(linemanager.employeeIdentificationNumber, linemanager.lastName)
+            altinnTilgangerClient.addAccess(principal.ident, linemanager.orgNumber.value)
+            aaregClient.arbeidsForholdForIdent[linemanager.manager.nationalIdentificationNumber.value] =
+                listOf(linemanager.orgNumber.value to "hovedenhet")
+            aaregClient.arbeidsForholdForIdent[linemanager.employeeIdentificationNumber.value] =
+                listOf(linemanager.orgNumber.value to "hovedenhet")
+            pdlService.prepareGetPersonResponse(linemanager.employeeIdentificationNumber.value, linemanager.lastName)
             pdlService.prepareGetPersonResponse(linemanager.manager)
         }
 
@@ -97,20 +99,20 @@ class ValidationServiceTest :
             principal: UserPrincipal,
         ) {
             altinnTilgangerClient.accessPolicy.clear()
-            altinnTilgangerClient.addAccess(principal.ident, linemanagerRevoke.orgNumber)
-            aaregClient.arbeidsForholdForIdent[linemanagerRevoke.employeeIdentificationNumber] =
-                listOf(linemanagerRevoke.orgNumber to "hovedenhet")
+            altinnTilgangerClient.addAccess(principal.ident, linemanagerRevoke.orgNumber.value)
+            aaregClient.arbeidsForholdForIdent[linemanagerRevoke.employeeIdentificationNumber.value] =
+                listOf(linemanagerRevoke.orgNumber.value to "hovedenhet")
             pdlService.prepareGetPersonResponse(
-                linemanagerRevoke.employeeIdentificationNumber,
+                linemanagerRevoke.employeeIdentificationNumber.value,
                 linemanagerRevoke.lastName,
             )
         }
 
         fun prepareCommonValidLinemanagerRevoke(linemanagerRevoke: LinemanagerRevoke) {
-            aaregClient.arbeidsForholdForIdent[linemanagerRevoke.employeeIdentificationNumber] =
-                listOf(linemanagerRevoke.orgNumber to "hovedenhet")
+            aaregClient.arbeidsForholdForIdent[linemanagerRevoke.employeeIdentificationNumber.value] =
+                listOf(linemanagerRevoke.orgNumber.value to "hovedenhet")
             pdlService.prepareGetPersonResponse(
-                linemanagerRevoke.employeeIdentificationNumber,
+                linemanagerRevoke.employeeIdentificationNumber.value,
                 linemanagerRevoke.lastName,
             )
         }
@@ -127,22 +129,22 @@ class ValidationServiceTest :
             it("should not thrown when all validation passes and principal is BrukerPrincipal") {
                 val fnr = altinnTilgangerClient.accessPolicy.first().hasAccess.first()
                 val principal = UserPrincipal(fnr, "token")
-                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = fnr)
+                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = PersonalIdentificationNumber(fnr))
 
                 prepareValidLinemanagerValidation(narmestelederRelasjonerWrite, principal)
 
                 val result = service.validateLinemanager(narmestelederRelasjonerWrite, principal)
 
-                result.employee.nationalIdentificationNumber shouldBe narmestelederRelasjonerWrite.employeeIdentificationNumber
-                result.manager.nationalIdentificationNumber shouldBe narmestelederRelasjonerWrite.manager.nationalIdentificationNumber
+                result.employee.nationalIdentificationNumber.value shouldBe narmestelederRelasjonerWrite.employeeIdentificationNumber.value
+                result.manager.nationalIdentificationNumber.value shouldBe narmestelederRelasjonerWrite.manager.nationalIdentificationNumber.value
                 coVerify(exactly = 1) {
                     altinnTilgangerService.validateTilgangToOrganization(
                         userPrincipal = eq(principal),
-                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber),
+                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber.value),
                     )
-                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber)
-                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.employeeIdentificationNumber)
-                    aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.employeeIdentificationNumber)
+                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber.value)
+                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.employeeIdentificationNumber.value)
+                    aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.employeeIdentificationNumber.value)
                 }
                 coVerify(exactly = 0) {
                     pdpService.hasAccessToResource(any(), any(), any())
@@ -152,11 +154,11 @@ class ValidationServiceTest :
             it("should throw BadRequestException when lastName of manager does mot match value in PDL") {
                 val fnr = altinnTilgangerClient.accessPolicy.first().hasAccess.first()
                 val principal = UserPrincipal(fnr, "token")
-                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = fnr)
+                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = PersonalIdentificationNumber(fnr))
 
                 prepareValidLinemanagerValidation(narmestelederRelasjonerWrite, principal)
                 pdlService.prepareGetPersonResponse(
-                    narmestelederRelasjonerWrite.manager.nationalIdentificationNumber,
+                    narmestelederRelasjonerWrite.manager.nationalIdentificationNumber.value,
                     differentLastName(narmestelederRelasjonerWrite.manager.lastName),
                 )
 
@@ -167,11 +169,11 @@ class ValidationServiceTest :
                 coVerify(exactly = 1) {
                     altinnTilgangerService.validateTilgangToOrganization(
                         userPrincipal = eq(principal),
-                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber),
+                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber.value),
                     )
-                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber)
-                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.employeeIdentificationNumber)
-                    aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.employeeIdentificationNumber)
+                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber.value)
+                    pdlService.getPersonOrThrowApiError(narmestelederRelasjonerWrite.employeeIdentificationNumber.value)
+                    aaregService.findArbeidsforholdByPersonIdent(narmestelederRelasjonerWrite.employeeIdentificationNumber.value)
                 }
                 coVerify(exactly = 0) {
                     pdpService.hasAccessToResource(any(), any(), any())
@@ -183,14 +185,14 @@ class ValidationServiceTest :
             it("should throw BadRequestException with NO_ACTIVE_SICK_LEAVE when no active sick leave exists") {
                 val fnr = altinnTilgangerClient.accessPolicy.first().hasAccess.first()
                 val principal = UserPrincipal(fnr, "token")
-                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = fnr)
+                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = PersonalIdentificationNumber(fnr))
 
                 altinnTilgangerClient.accessPolicy.clear()
-                altinnTilgangerClient.addAccess(principal.ident, narmestelederRelasjonerWrite.orgNumber)
+                altinnTilgangerClient.addAccess(principal.ident, narmestelederRelasjonerWrite.orgNumber.value)
                 coEvery {
                     dinesykmeldteService.getIsActiveSykmelding(
-                        narmestelederRelasjonerWrite.employeeIdentificationNumber,
-                        narmestelederRelasjonerWrite.orgNumber,
+                        narmestelederRelasjonerWrite.employeeIdentificationNumber.value,
+                        narmestelederRelasjonerWrite.orgNumber.value,
                     )
                 } returns false
 
@@ -202,7 +204,7 @@ class ValidationServiceTest :
                 coVerify(exactly = 1) {
                     altinnTilgangerService.validateTilgangToOrganization(
                         userPrincipal = eq(principal),
-                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber),
+                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber.value),
                     )
                 }
                 coVerify(exactly = 0) {
@@ -214,16 +216,16 @@ class ValidationServiceTest :
             it("should skip employee last name validation when validateEmployeeLastName is false") {
                 val fnr = altinnTilgangerClient.accessPolicy.first().hasAccess.first()
                 val principal = UserPrincipal(fnr, "token")
-                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = fnr)
+                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = PersonalIdentificationNumber(fnr))
 
                 altinnTilgangerClient.accessPolicy.clear()
-                altinnTilgangerClient.addAccess(principal.ident, narmestelederRelasjonerWrite.orgNumber)
-                aaregClient.arbeidsForholdForIdent[narmestelederRelasjonerWrite.manager.nationalIdentificationNumber] =
-                    listOf(narmestelederRelasjonerWrite.orgNumber to "hovedenhet")
-                aaregClient.arbeidsForholdForIdent[narmestelederRelasjonerWrite.employeeIdentificationNumber] =
-                    listOf(narmestelederRelasjonerWrite.orgNumber to "hovedenhet")
+                altinnTilgangerClient.addAccess(principal.ident, narmestelederRelasjonerWrite.orgNumber.value)
+                aaregClient.arbeidsForholdForIdent[narmestelederRelasjonerWrite.manager.nationalIdentificationNumber.value] =
+                    listOf(narmestelederRelasjonerWrite.orgNumber.value to "hovedenhet")
+                aaregClient.arbeidsForholdForIdent[narmestelederRelasjonerWrite.employeeIdentificationNumber.value] =
+                    listOf(narmestelederRelasjonerWrite.orgNumber.value to "hovedenhet")
                 pdlService.prepareGetPersonResponse(
-                    narmestelederRelasjonerWrite.employeeIdentificationNumber,
+                    narmestelederRelasjonerWrite.employeeIdentificationNumber.value,
                     differentLastName(narmestelederRelasjonerWrite.lastName),
                 )
                 pdlService.prepareGetPersonResponse(narmestelederRelasjonerWrite.manager)
@@ -240,7 +242,7 @@ class ValidationServiceTest :
             it("should call AltinnTilgangerService first when principal is BrukerPrincipal") {
                 val fnr = altinnTilgangerClient.accessPolicy.first().hasAccess.first()
                 val principal = UserPrincipal(fnr, "token")
-                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = fnr)
+                val narmestelederRelasjonerWrite = linemanager().copy(employeeIdentificationNumber = PersonalIdentificationNumber(fnr))
 
                 shouldThrow<ApiErrorException.ForbiddenException> {
                     service.validateLinemanager(narmestelederRelasjonerWrite, principal)
@@ -248,7 +250,7 @@ class ValidationServiceTest :
                 coVerify(exactly = 1) {
                     altinnTilgangerService.validateTilgangToOrganization(
                         userPrincipal = eq(principal),
-                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber),
+                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber.value),
                     )
                 }
                 coVerify(exactly = 0) {
@@ -263,8 +265,8 @@ class ValidationServiceTest :
                 val requestOrgnumber = userWithAccess.altinnTilgangerResponse.hierarki.first().orgnr
                 val systemUserOrgnumber = requestOrgnumber.reversed()
                 val narmestelederRelasjonerWrite = linemanager().copy(
-                    employeeIdentificationNumber = userWithAccess.hasAccess.first(),
-                    orgNumber = userWithAccess.altinnTilgangerResponse.hierarki.first().orgnr,
+                    employeeIdentificationNumber = PersonalIdentificationNumber(userWithAccess.hasAccess.first()),
+                    orgNumber = OrganizationNumber(userWithAccess.altinnTilgangerResponse.hierarki.first().orgnr),
                 )
                 val principal = DefaultSystemPrincipal.copy(
                     ident = "0192:$systemUserOrgnumber",
@@ -276,20 +278,20 @@ class ValidationServiceTest :
                 coVerify(exactly = 0) {
                     altinnTilgangerService.validateTilgangToOrganization(
                         userPrincipal = any<UserPrincipal>(),
-                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber),
+                        orgnummer = eq(narmestelederRelasjonerWrite.orgNumber.value),
                     )
                 }
                 coVerify(exactly = 0) {
-                    pdlService.getPersonOrThrowApiError(eq(narmestelederRelasjonerWrite.employeeIdentificationNumber))
-                    pdlService.getPersonOrThrowApiError(eq(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber))
+                    pdlService.getPersonOrThrowApiError(eq(narmestelederRelasjonerWrite.employeeIdentificationNumber.value))
+                    pdlService.getPersonOrThrowApiError(eq(narmestelederRelasjonerWrite.manager.nationalIdentificationNumber.value))
                 }
                 coVerify(exactly = 1) {
                     pdpService.hasAccessToResource(
                         user = match<System> { it.id == "systemId" },
-                        orgNumberSet = eq(setOf(narmestelederRelasjonerWrite.orgNumber)),
+                        orgNumberSet = eq(setOf(narmestelederRelasjonerWrite.orgNumber.value)),
                         resource = eq("nav_syfo_oppgi-narmesteleder"),
                     )
-                    aaregService.findArbeidsforholdByPersonIdent(eq(narmestelederRelasjonerWrite.employeeIdentificationNumber))
+                    aaregService.findArbeidsforholdByPersonIdent(eq(narmestelederRelasjonerWrite.employeeIdentificationNumber.value))
                 }
             }
         }
@@ -298,7 +300,7 @@ class ValidationServiceTest :
             it("should call AltinnTilgangerService when principal is BrukerPrincipal") {
                 val fnr = altinnTilgangerClient.accessPolicy.first().hasAccess.first()
                 val principal = UserPrincipal(fnr, "token")
-                val narmesteLederAvkreft = linemanagerRevoke().copy(employeeIdentificationNumber = fnr)
+                val narmesteLederAvkreft = linemanagerRevoke().copy(employeeIdentificationNumber = PersonalIdentificationNumber(fnr))
 
                 shouldThrow<ApiErrorException.ForbiddenException> {
                     service.validateLinemanagerRevoke(narmesteLederAvkreft, principal)
@@ -306,7 +308,7 @@ class ValidationServiceTest :
                 coVerify(exactly = 1) {
                     altinnTilgangerService.validateTilgangToOrganization(
                         userPrincipal = eq(principal),
-                        orgnummer = eq(narmesteLederAvkreft.orgNumber),
+                        orgnummer = eq(narmesteLederAvkreft.orgNumber.value),
                     )
                     aaregService.findArbeidsforholdByPersonIdent(any())
                 }
@@ -325,12 +327,12 @@ class ValidationServiceTest :
 
                 val result = service.validateLinemanagerRevoke(narmesteLederAvkreft, principal)
 
-                result.nationalIdentificationNumber shouldBe narmesteLederAvkreft.employeeIdentificationNumber
+                result.nationalIdentificationNumber.value shouldBe narmesteLederAvkreft.employeeIdentificationNumber.value
                 result.name.etternavn shouldBe narmesteLederAvkreft.lastName
                 coVerify(exactly = 1) {
                     altinnTilgangerService.validateTilgangToOrganization(
                         userPrincipal = eq(principal),
-                        orgnummer = eq(narmesteLederAvkreft.orgNumber),
+                        orgnummer = eq(narmesteLederAvkreft.orgNumber.value),
                     )
                 }
                 coVerify(exactly = 0) {
@@ -346,12 +348,12 @@ class ValidationServiceTest :
 
                 val result = service.validateLinemanagerRevoke(narmesteLederAvkreft, principal)
 
-                result.nationalIdentificationNumber shouldBe narmesteLederAvkreft.employeeIdentificationNumber
+                result.nationalIdentificationNumber.value shouldBe narmesteLederAvkreft.employeeIdentificationNumber.value
                 result.name.etternavn shouldBe narmesteLederAvkreft.lastName
                 coVerify(exactly = 1) {
                     pdpService.hasAccessToResource(
                         user = match<System> { it.id == "systemId" },
-                        orgNumberSet = eq(setOf(narmesteLederAvkreft.orgNumber)),
+                        orgNumberSet = eq(setOf(narmesteLederAvkreft.orgNumber.value)),
                         resource = eq("nav_syfo_oppgi-narmesteleder"),
                     )
                 }
@@ -369,11 +371,11 @@ class ValidationServiceTest :
                 val narmesteLederAvkreft = linemanagerRevoke()
 
                 altinnTilgangerClient.accessPolicy.clear()
-                altinnTilgangerClient.addAccess(principal.ident, narmesteLederAvkreft.orgNumber)
-                aaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber] =
-                    listOf(narmesteLederAvkreft.orgNumber to "hovedenhet")
+                altinnTilgangerClient.addAccess(principal.ident, narmesteLederAvkreft.orgNumber.value)
+                aaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber.value] =
+                    listOf(narmesteLederAvkreft.orgNumber.value to "hovedenhet")
                 pdlService.prepareGetPersonResponse(
-                    narmesteLederAvkreft.employeeIdentificationNumber,
+                    narmesteLederAvkreft.employeeIdentificationNumber.value,
                     differentLastName(narmesteLederAvkreft.lastName),
                 )
 
@@ -389,9 +391,9 @@ class ValidationServiceTest :
                 val narmesteLederAvkreft = linemanagerRevoke()
 
                 altinnTilgangerClient.accessPolicy.clear()
-                altinnTilgangerClient.addAccess(principal.ident, narmesteLederAvkreft.orgNumber)
-                aaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber] =
-                    listOf(differentOrgNumber(narmesteLederAvkreft.orgNumber) to "hovedenhet")
+                altinnTilgangerClient.addAccess(principal.ident, narmesteLederAvkreft.orgNumber.value)
+                aaregClient.arbeidsForholdForIdent[narmesteLederAvkreft.employeeIdentificationNumber.value] =
+                    listOf(differentOrgNumber(narmesteLederAvkreft.orgNumber.value) to "hovedenhet")
 
                 val exception = shouldThrow<ApiErrorException.BadRequestException> {
                     service.validateLinemanagerRevoke(narmesteLederAvkreft, principal)

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/validators/NameValidatorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/validators/NameValidatorTest.kt
@@ -9,6 +9,7 @@ import linemanager
 import linemanagerRevoke
 import no.nav.syfo.application.api.ErrorType
 import no.nav.syfo.application.exception.ApiErrorException
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.pdl.Person
 import no.nav.syfo.pdl.client.Navn
 
@@ -20,7 +21,7 @@ class NameValidatorTest :
                 mellomnavn = null,
                 etternavn = lastName,
             ),
-            nationalIdentificationNumber = fnr,
+            nationalIdentificationNumber = PersonalIdentificationNumber(fnr),
         )
 
         describe("validateLinemanagerLastName") {
@@ -28,7 +29,7 @@ class NameValidatorTest :
                 val linemanager = linemanager()
                 val manager = person(
                     lastName = linemanager.manager.lastName.reversed(),
-                    fnr = linemanager.manager.nationalIdentificationNumber,
+                    fnr = linemanager.manager.nationalIdentificationNumber.value,
                 )
 
                 val exception = shouldThrow<ApiErrorException.BadRequestException> {
@@ -43,7 +44,7 @@ class NameValidatorTest :
                 val linemanager = linemanager()
                 val manager = person(
                     lastName = linemanager.manager.lastName.lowercase(),
-                    fnr = linemanager.manager.nationalIdentificationNumber,
+                    fnr = linemanager.manager.nationalIdentificationNumber.value,
                 )
 
                 shouldNotThrow<ApiErrorException.BadRequestException> {
@@ -57,7 +58,7 @@ class NameValidatorTest :
                 val linemanager = linemanager()
                 val employee = person(
                     lastName = linemanager.lastName.lowercase(),
-                    fnr = linemanager.employeeIdentificationNumber,
+                    fnr = linemanager.employeeIdentificationNumber.value,
                 )
 
                 shouldNotThrow<ApiErrorException.BadRequestException> {
@@ -69,7 +70,7 @@ class NameValidatorTest :
                 val linemanager = linemanager()
                 val employee = person(
                     lastName = linemanager.lastName,
-                    fnr = linemanager.employeeIdentificationNumber,
+                    fnr = linemanager.employeeIdentificationNumber.value,
                 )
 
                 shouldNotThrow<ApiErrorException.BadRequestException> {
@@ -81,7 +82,7 @@ class NameValidatorTest :
                 val linemanager = linemanager()
                 val employee = person(
                     lastName = linemanager.lastName.reversed(),
-                    fnr = linemanager.employeeIdentificationNumber,
+                    fnr = linemanager.employeeIdentificationNumber.value,
                 )
 
                 val exception = shouldThrow<ApiErrorException.BadRequestException> {
@@ -98,7 +99,7 @@ class NameValidatorTest :
                 val linemanagerRevoke = linemanagerRevoke()
                 val employee = person(
                     lastName = linemanagerRevoke.lastName.lowercase(),
-                    fnr = linemanagerRevoke.employeeIdentificationNumber,
+                    fnr = linemanagerRevoke.employeeIdentificationNumber.value,
                 )
 
                 shouldNotThrow<ApiErrorException.BadRequestException> {
@@ -110,7 +111,7 @@ class NameValidatorTest :
                 val linemanagerRevoke = linemanagerRevoke()
                 val employee = person(
                     lastName = linemanagerRevoke.lastName.reversed(),
-                    fnr = linemanagerRevoke.employeeIdentificationNumber,
+                    fnr = linemanagerRevoke.employeeIdentificationNumber.value,
                 )
 
                 val exception = shouldThrow<ApiErrorException.BadRequestException> {

--- a/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
@@ -56,7 +56,7 @@ class PdlServiceTest :
 
                 val result = pdlService.getPersonFor(fnr)
 
-                result.nationalIdentificationNumber shouldBe fnr
+                result.nationalIdentificationNumber.value shouldBe fnr
                 result.name shouldBe navn
                 coVerify(exactly = 1) { pdlClient.getPerson(fnr) }
             }
@@ -123,7 +123,7 @@ class PdlServiceTest :
 
                 val result = pdlService.getPersonOrThrowApiError(fnr)
 
-                result.nationalIdentificationNumber shouldBe fnr
+                result.nationalIdentificationNumber.value shouldBe fnr
                 result.name shouldBe navn
                 coVerify(exactly = 1) { pdlClient.getPerson(fnr) }
             }

--- a/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.valkey.PdlCache
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.pdl.client.GetPersonBolkResponse
 import no.nav.syfo.pdl.client.GetPersonResponse
 import no.nav.syfo.pdl.client.HentIdenterBolk
@@ -182,7 +183,7 @@ class PdlServiceTest :
                 val result = pdlService.getPersonsBolk(listOf(fnr))
 
                 result[fnr]?.name shouldBe navn
-                result[fnr]?.nationalIdentificationNumber shouldBe fnr
+                result[fnr]?.nationalIdentificationNumber shouldBe PersonalIdentificationNumber(fnr)
                 coVerify(exactly = 1) { pdlClient.getSystemToken() }
                 coVerify(exactly = 1) { pdlClient.getPersonBolk(listOf(fnr), token) }
             }
@@ -249,7 +250,7 @@ class PdlServiceTest :
 
                 result.size shouldBe 2
                 result[successfulFnr]?.name shouldBe navn
-                result[successfulFnr]?.nationalIdentificationNumber shouldBe successfulFnr
+                result[successfulFnr]?.nationalIdentificationNumber shouldBe PersonalIdentificationNumber(successfulFnr)
                 result.containsKey(notFoundFnr) shouldBe true
                 result[notFoundFnr] shouldBe null
                 failedChunkFnrs.any { result.containsKey(it) } shouldBe false

--- a/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.TestDB
+import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.exposed.PersonBatchInsertRow
 import no.nav.syfo.narmesteleder.exposed.PersonEntity
 import no.nav.syfo.narmesteleder.exposed.PersonTable
@@ -47,7 +48,7 @@ class PersonEnrichmentServiceTest :
 
         fun createPdlPerson(fnr: String, fornavn: String = "Ola") = Person(
             name = Navn(fornavn = fornavn, mellomnavn = null, etternavn = "Nordmann"),
-            nationalIdentificationNumber = fnr,
+            nationalIdentificationNumber = PersonalIdentificationNumber(fnr),
             foedselsdato = null,
         )
 
@@ -74,7 +75,7 @@ class PersonEnrichmentServiceTest :
                 coEvery { pdlService.getPersonsBolk(listOf(fnr)) } returns mapOf(
                     fnr to Person(
                         name = navn,
-                        nationalIdentificationNumber = fnr,
+                        nationalIdentificationNumber = PersonalIdentificationNumber(fnr),
                         foedselsdato = Foedselsdato(foedselsdato),
                     ),
                 )
@@ -112,7 +113,7 @@ class PersonEnrichmentServiceTest :
                 coEvery { pdlService.getPersonsBolk(any()) } returns mapOf(
                     fnr1 to Person(
                         name = navn1,
-                        nationalIdentificationNumber = fnr1,
+                        nationalIdentificationNumber = PersonalIdentificationNumber(fnr1),
                         foedselsdato = null,
                     ),
                     fnr2 to null,

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandlerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandlerTest.kt
@@ -279,5 +279,25 @@ class SendtSykmeldingHandlerTest :
                     narmesteLederService.createNewNlBehov(any(), any(), any())
                 }
             }
+
+            it("should not create NL behov when fnr is invalid") {
+                val message = defaultSendtSykmeldingMessage(fnr = "123")
+
+                handler.handleNarmestelederbehov(message)
+
+                coVerify(exactly = 0) {
+                    narmesteLederService.createNewNlBehov(any(), any(), any(), any())
+                }
+            }
+
+            it("should not create NL behov when orgnummer is invalid") {
+                val message = defaultSendtSykmeldingMessage(orgnummer = "123")
+
+                handler.handleNarmestelederbehov(message)
+
+                coVerify(exactly = 0) {
+                    narmesteLederService.createNewNlBehov(any(), any(), any(), any())
+                }
+            }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandlerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/kafka/SendtSykmeldingHandlerTest.kt
@@ -264,8 +264,8 @@ class SendtSykmeldingHandlerTest :
                     )
                 }
 
-                assert(nlBehovSlot.captured.employeeIdentificationNumber == fnr)
-                assert(nlBehovSlot.captured.orgNumber == orgnummer)
+                assert(nlBehovSlot.captured.employeeIdentificationNumber.value == fnr)
+                assert(nlBehovSlot.captured.orgNumber.value == orgnummer)
                 assert(skipCheckSlot.captured)
             }
 


### PR DESCRIPTION
## Beskrivelse

Innfører `@JvmInline value class` for `OrganizationNumber` (9 siffer) og `PersonalIdentificationNumber` (11 siffer) i domenemodellen. Typene validerer ved konstruksjon og gir kompileringsfeil ved blanding.

Closes #342

## Endringer

- **Nye value classes** med `require`-validering i `init` og `companion parse(): Result`
- **7 domenemodeller** oppdatert til sterkere typer
- **API-feilhåndtering**: 400 Bad Request for ugyldig body og query-params (`ErrorType.INVALID_FORMAT`)
- **OpenAPI** oppdatert med digit-patterns
- **Kafka/DB** beholder String — konverterer ved grenser med `.value` / constructor
- **Tester**: unit tests for value classes + API-valideringstester

## Avgrensning

Dette er fase 1. Følgende er utsatt:
- Kafka-robusthet: `parse()` + logg & skip i handlers
- DB-data inventory
- OpenAPI `mainOrgnumber` → `mainOrgNumber` mismatch (pre-eksisterende)

## Verifisering

- `./gradlew build` ✅
- Kryssmodell code review (inspektør-claude + inspektør-gpt) ✅
