### PR TITLE
feat(person): berik persondata med navn fra PDL via bulk-oppslag

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -144,5 +144,7 @@ spec:
       value: "true"
     - name: PERSIST_NARMESTELEDER_REGISTER
       value: "false"
+    - name: PERSON_ENRICHMENT_TASK_ENABLED
+      value: "true"
   envFrom:
     - secret: altinn-subscription-key

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -136,5 +136,7 @@ spec:
       value: "true"
     - name: PERSIST_NARMESTELEDER_REGISTER
       value: "false"
+    - name: PERSON_ENRICHMENT_TASK_ENABLED
+      value: "false"
   envFrom:
     - secret: altinn-subscription-key

--- a/src/main/kotlin/no/nav/syfo/application/environment/OtherEnvironmentProperties.kt
+++ b/src/main/kotlin/no/nav/syfo/application/environment/OtherEnvironmentProperties.kt
@@ -13,6 +13,8 @@ data class OtherEnvironmentProperties(
     val persistSendtSykmelding: Boolean,
     val maintenanceTaskEnabled: Boolean,
     val persistNarmestelederRegister: Boolean,
+    val personEnrichmentTaskDelay: String,
+    val personEnrichmentTaskEnabled: Boolean,
 ) {
     companion object {
         fun createFromEnvVars() = OtherEnvironmentProperties(
@@ -31,6 +33,8 @@ data class OtherEnvironmentProperties(
             maintenanceTaskDelay = getEnvVar("MAINTENANCE_TASK_DELAY", "24h"),
             maintenanceTaskEnabled = getEnvVar("BEHOV_MAINTENANCE_TASK_ENABLED", "false").toBoolean(),
             persistNarmestelederRegister = getEnvVar("PERSIST_NARMESTELEDER_REGISTER", "false").toBoolean(),
+            personEnrichmentTaskDelay = getEnvVar("PERSON_ENRICHMENT_TASK_DELAY", "5m"),
+            personEnrichmentTaskEnabled = getEnvVar("PERSON_ENRICHMENT_TASK_ENABLED", "false").toBoolean(),
         )
 
         fun createForLocal() = OtherEnvironmentProperties(
@@ -46,6 +50,8 @@ data class OtherEnvironmentProperties(
             maintenanceTaskEnabled = true,
             electorSSEUrl = "not.applicable",
             persistNarmestelederRegister = true,
+            personEnrichmentTaskDelay = "1m",
+            personEnrichmentTaskEnabled = true,
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederRegisterService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederRegisterService.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.narmesteleder.exposed.narmestelederTable
 import no.nav.syfo.narmesteleder.exposed.personTable
 import no.nav.syfo.narmesteleder.kafka.LeesahNarmestelederRecord
 import no.nav.syfo.narmesteleder.kafka.model.NarmestelederLeesahKafkaMessage
+import no.nav.syfo.person.domain.PersonStatus
 import org.jetbrains.exposed.v1.core.Transaction
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -51,13 +52,13 @@ class NarmestelederRegisterService(
             personFnrs.add(
                 PersonBatchInsertRow(
                     fnr = record.message.fnr,
-                    status = "PENDING"
+                    status = PersonStatus.PENDING.name
                 )
             )
             personFnrs.add(
                 PersonBatchInsertRow(
                     fnr = record.message.narmesteLederFnr,
-                    status = "PENDING"
+                    status = PersonStatus.PENDING.name
                 )
             )
         }

--- a/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
@@ -1,5 +1,8 @@
 package no.nav.syfo.pdl
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.valkey.PdlCache
 import no.nav.syfo.pdl.client.GetPersonBolkResponse
@@ -8,6 +11,8 @@ import no.nav.syfo.pdl.client.Ident.Companion.GRUPPE_IDENT_FNR
 import no.nav.syfo.pdl.exception.PdlRequestException
 import no.nav.syfo.pdl.exception.PdlResourceNotFoundException
 import no.nav.syfo.util.logger
+
+private const val PDL_CHUNK_SIZE = 100
 
 class PdlService(
     private val pdlClient: IPdlClient,
@@ -49,11 +54,28 @@ class PdlService(
     }
 
     suspend fun getPersonsBolk(fnrs: List<String>): Map<String, Person?> {
-        val response = pdlClient.getPersonBolk(fnrs)
-        if (!response.errors.isNullOrEmpty()) {
-            logger.error("Errors in getPersonsBolk response from PDL: ${response.errors}")
+        if (fnrs.isEmpty()) {
+            return emptyMap()
         }
-        return response.toPersonMap()
+
+        val token = pdlClient.getSystemToken()
+        val responses = coroutineScope {
+            fnrs.chunked(PDL_CHUNK_SIZE)
+                .map { fnrChunk ->
+                    async {
+                        pdlClient.getPersonBolk(fnrChunk, token)
+                    }
+                }
+                .awaitAll()
+        }
+        return responses
+            .onEach { response ->
+                if (!response.errors.isNullOrEmpty()) {
+                    logger.error("Errors in getPersonsBolk response from PDL: ${response.errors}")
+                }
+            }
+            .flatMap { it.toPersonMap().entries }
+            .associate { (fnr, person) -> fnr to person }
     }
 
     private fun GetPersonBolkResponse.toPersonMap(): Map<String, Person?> = data?.hentPersonBolk

--- a/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.pdl
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -63,19 +64,29 @@ class PdlService(
             fnrs.chunked(PDL_CHUNK_SIZE)
                 .map { fnrChunk ->
                     async {
-                        pdlClient.getPersonBolk(fnrChunk, token)
+                        getPersonBolkChunk(fnrChunk = fnrChunk, token = token)
                     }
                 }
-                .awaitAll()
+                .awaitAll().filterNotNull()
         }
         return responses
             .onEach { response ->
-                if (!response.errors.isNullOrEmpty()) {
-                    logger.error("Errors in getPersonsBolk response from PDL: ${response.errors}")
+                val errorCount = response.errors?.size ?: 0
+                if (errorCount > 0) {
+                    logger.error("Errors in getPersonsBolk response from PDL, errorCount=$errorCount")
                 }
             }
             .flatMap { it.toPersonMap().entries }
             .associate { (fnr, person) -> fnr to person }
+    }
+
+    private suspend fun getPersonBolkChunk(fnrChunk: List<String>, token: String): GetPersonBolkResponse? = try {
+        pdlClient.getPersonBolk(fnrChunk, token)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: PdlRequestException) {
+        logger.error("Error when fetching person bulk from PDL for chunk of size ${fnrChunk.size}", e)
+        null
     }
 
     private fun GetPersonBolkResponse.toPersonMap(): Map<String, Person?> = data?.hentPersonBolk

--- a/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/PdlService.kt
@@ -2,15 +2,18 @@ package no.nav.syfo.pdl
 
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.valkey.PdlCache
+import no.nav.syfo.pdl.client.GetPersonBolkResponse
 import no.nav.syfo.pdl.client.IPdlClient
 import no.nav.syfo.pdl.client.Ident.Companion.GRUPPE_IDENT_FNR
 import no.nav.syfo.pdl.exception.PdlRequestException
 import no.nav.syfo.pdl.exception.PdlResourceNotFoundException
+import no.nav.syfo.util.logger
 
 class PdlService(
     private val pdlClient: IPdlClient,
     private val pdlCache: PdlCache
 ) {
+    private val logger = logger()
 
     suspend fun getPersonFor(fnr: String): Person {
         val response = pdlClient.getPerson(fnr)
@@ -44,4 +47,28 @@ class PdlService(
             throw ApiErrorException.InternalServerErrorException("Error when fetching person from PDL", e)
         }
     }
+
+    suspend fun getPersonsBolk(fnrs: List<String>): Map<String, Person?> {
+        val response = pdlClient.getPersonBolk(fnrs)
+        if (!response.errors.isNullOrEmpty()) {
+            logger.error("Errors in getPersonsBolk response from PDL: ${response.errors}")
+        }
+        return response.toPersonMap()
+    }
+
+    private fun GetPersonBolkResponse.toPersonMap(): Map<String, Person?> = data?.hentPersonBolk
+        ?.associateBy { it.ident }
+        ?.mapValues { (_, bolk) ->
+            if (bolk.code == "ok" && bolk.person != null) {
+                val navn = bolk.person.navn?.firstOrNull() ?: return@mapValues null
+                Person(
+                    name = navn,
+                    nationalIdentificationNumber = bolk.ident,
+                    foedselsdato = bolk.person.foedselsdato?.firstOrNull(),
+                )
+            } else {
+                null
+            }
+        }
+        ?: emptyMap()
 }

--- a/src/main/kotlin/no/nav/syfo/pdl/client/FakePdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/FakePdlClient.kt
@@ -5,6 +5,8 @@ import no.nav.syfo.pdl.client.Ident.Companion.GRUPPE_IDENT_FNR
 import java.util.Random
 
 class FakePdlClient : IPdlClient {
+    override suspend fun getSystemToken(): String = "token"
+
     override suspend fun getPerson(fnr: String): GetPersonResponse {
         val faker = Faker(Random(fnr.toLong()))
         val navn = faker.name()
@@ -31,7 +33,7 @@ class FakePdlClient : IPdlClient {
         )
     }
 
-    override suspend fun getPersonBolk(fnrs: List<String>): GetPersonBolkResponse {
+    override suspend fun getPersonBolk(fnrs: List<String>, token: String): GetPersonBolkResponse {
         val hentPersonBolk = fnrs.map { fnr ->
             val faker = Faker(Random(fnr.toLong()))
             val navn = faker.name()

--- a/src/main/kotlin/no/nav/syfo/pdl/client/FakePdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/FakePdlClient.kt
@@ -1,0 +1,68 @@
+package no.nav.syfo.pdl.client
+
+import net.datafaker.Faker
+import no.nav.syfo.pdl.client.Ident.Companion.GRUPPE_IDENT_FNR
+import java.util.Random
+
+class FakePdlClient : IPdlClient {
+    override suspend fun getPerson(fnr: String): GetPersonResponse {
+        val faker = Faker(Random(fnr.toLong()))
+        val navn = faker.name()
+        val foedselsdato = faker.timeAndDate().birthday()
+        return GetPersonResponse(
+            data = ResponseData(
+                person = PersonResponse(
+                    navn = listOf(
+                        Navn(
+                            fornavn = navn.firstName(),
+                            mellomnavn = navn.nameWithMiddle().split(" ").getOrNull(1),
+                            etternavn = navn.lastName(),
+                        ),
+                    ),
+                    foedselsdato = listOf(Foedselsdato(foedselsdato)),
+                ),
+                identer = IdentResponse(
+                    identer = listOf(
+                        Ident(ident = fnr, gruppe = GRUPPE_IDENT_FNR),
+                    ),
+                ),
+            ),
+            errors = null,
+        )
+    }
+
+    override suspend fun getPersonBolk(fnrs: List<String>): GetPersonBolkResponse {
+        val hentPersonBolk = fnrs.map { fnr ->
+            val faker = Faker(Random(fnr.toLong()))
+            val navn = faker.name()
+            HentPersonBolk(
+                ident = fnr,
+                person = Person(
+                    navn = listOf(
+                        Navn(
+                            fornavn = navn.firstName(),
+                            mellomnavn = navn.nameWithMiddle().split(" ").getOrNull(1),
+                            etternavn = navn.lastName(),
+                        ),
+                    ),
+                    foedselsdato = listOf(Foedselsdato(faker.timeAndDate().birthday())),
+                ),
+                code = "ok",
+            )
+        }
+        val hentIdenterBolk = fnrs.map { fnr ->
+            HentIdenterBolk(
+                ident = fnr,
+                identer = listOf(PdlIdent(ident = fnr, gruppe = GRUPPE_IDENT_FNR)),
+                code = "ok",
+            )
+        }
+        return GetPersonBolkResponse(
+            data = PersonBolkResponseData(
+                hentPersonBolk = hentPersonBolk,
+                hentIdenterBolk = hentIdenterBolk,
+            ),
+            errors = null,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/pdl/client/GetPersonRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/GetPersonRequest.kt
@@ -1,3 +1,5 @@
 package no.nav.syfo.pdl.client
 
 data class GetPersonRequest(val query: String, val variables: GetPersonVariables)
+
+data class GetPersonBolkRequest(val query: String, val variables: GetPersonBolkVariables)

--- a/src/main/kotlin/no/nav/syfo/pdl/client/GetPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/GetPersonResponse.kt
@@ -65,3 +65,32 @@ data class ErrorDetails(
     val cause: String? = null,
     val policy: String? = null,
 )
+
+data class HentPersonBolk(
+    val ident: String,
+    val person: Person?,
+    val code: String,
+)
+
+data class Person(
+    val navn: List<Navn>?,
+    val foedselsdato: List<Foedselsdato>? = null,
+)
+
+data class HentIdenterBolk(
+    val ident: String,
+    val identer: List<PdlIdent>?,
+    val code: String,
+)
+
+data class PdlIdent(val ident: String, val gruppe: String)
+
+data class GetPersonBolkResponse(
+    val data: PersonBolkResponseData?,
+    val errors: List<ResponseError>?,
+)
+
+data class PersonBolkResponseData(
+    val hentPersonBolk: List<HentPersonBolk>?,
+    val hentIdenterBolk: List<HentIdenterBolk>?,
+)

--- a/src/main/kotlin/no/nav/syfo/pdl/client/GetPersonVariables.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/GetPersonVariables.kt
@@ -1,3 +1,5 @@
 package no.nav.syfo.pdl.client
 
 data class GetPersonVariables(val ident: String)
+
+data class GetPersonBolkVariables(val identer: List<String>)

--- a/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
@@ -39,8 +39,9 @@ private val getPersonQuery =
         .trimIndent()
 
 interface IPdlClient {
+    suspend fun getSystemToken(): String
     suspend fun getPerson(fnr: String): GetPersonResponse
-    suspend fun getPersonBolk(fnrs: List<String>): GetPersonBolkResponse
+    suspend fun getPersonBolk(fnrs: List<String>, token: String): GetPersonBolkResponse
 }
 
 class PdlClient(
@@ -57,11 +58,13 @@ class PdlClient(
                 ?: throw IllegalStateException("Could not load hentPersonBolk.graphql")
     }
 
+    override suspend fun getSystemToken(): String = texasHttpClient.systemToken(
+        "azuread",
+        TexasHttpClient.getTarget(scope)
+    ).accessToken
+
     override suspend fun getPerson(fnr: String): GetPersonResponse {
-        val token = texasHttpClient.systemToken(
-            "azuread",
-            TexasHttpClient.getTarget(scope)
-        ).accessToken
+        val token = getSystemToken()
 
         val getPersonRequest =
             GetPersonRequest(
@@ -90,12 +93,7 @@ class PdlClient(
         }
     }
 
-    override suspend fun getPersonBolk(fnrs: List<String>): GetPersonBolkResponse {
-        val token = texasHttpClient.systemToken(
-            "azuread",
-            TexasHttpClient.getTarget(scope)
-        ).accessToken
-
+    override suspend fun getPersonBolk(fnrs: List<String>, token: String): GetPersonBolkResponse {
         val request = GetPersonBolkRequest(
             query = getPersonBolkQuery,
             variables = GetPersonBolkVariables(identer = fnrs),
@@ -109,9 +107,6 @@ class PdlClient(
                     header(HttpHeaders.ContentType, "application/json")
                 }
                 .body<GetPersonBolkResponse>()
-            if (!response.errors.isNullOrEmpty()) {
-                logger.error("Error when requesting persons in bolk from PDL. Got errors: ${response.errors}")
-            }
             return response
         } catch (e: ResponseException) {
             logger.error("Error on getPersonBolk query to PDL. Got status ${e.response.status} and message ${e.message}")

--- a/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
@@ -7,14 +7,11 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpHeaders
-import net.datafaker.Faker
-import no.nav.syfo.pdl.client.Ident.Companion.GRUPPE_IDENT_FNR
 import no.nav.syfo.pdl.exception.PdlRequestException
 import no.nav.syfo.pdl.exception.PdlResourceNotFoundException
 import no.nav.syfo.texas.client.TexasHttpClient
 import no.nav.syfo.util.logger
 import org.intellij.lang.annotations.Language
-import java.util.*
 
 private const val BEHANDLINGSNUMMER_NARMESTELEDER = "B506"
 private const val PDL_BEHANDLINGSNUMMER_HEADER = "behandlingsnummer"
@@ -43,6 +40,7 @@ private val getPersonQuery =
 
 interface IPdlClient {
     suspend fun getPerson(fnr: String): GetPersonResponse
+    suspend fun getPersonBolk(fnrs: List<String>): GetPersonBolkResponse
 }
 
 class PdlClient(
@@ -53,6 +51,10 @@ class PdlClient(
 ) : IPdlClient {
     companion object {
         private val logger = logger()
+        private val getPersonBolkQuery =
+            PdlClient::class.java.getResource("/graphql/hentPersonBolk.graphql")
+                ?.readText()
+                ?: throw IllegalStateException("Could not load hentPersonBolk.graphql")
     }
 
     override suspend fun getPerson(fnr: String): GetPersonResponse {
@@ -87,32 +89,33 @@ class PdlClient(
             throw PdlRequestException("Error on findPerson query to PDL", e)
         }
     }
-}
 
-class FakePdlClient : IPdlClient {
-    override suspend fun getPerson(fnr: String): GetPersonResponse {
-        val faker = Faker(Random(fnr.toLong()))
-        val navn = faker.name()
-        val foedselsdato = faker.timeAndDate().birthday()
-        return GetPersonResponse(
-            data = ResponseData(
-                person = PersonResponse(
-                    navn = listOf(
-                        Navn(
-                            fornavn = navn.firstName(),
-                            mellomnavn = navn.nameWithMiddle().split(" ").getOrNull(1),
-                            etternavn = navn.lastName(),
-                        ),
-                    ),
-                    foedselsdato = listOf(Foedselsdato(foedselsdato))
-                ),
-                identer = IdentResponse(
-                    identer = listOf(
-                        Ident(ident = fnr, gruppe = GRUPPE_IDENT_FNR),
-                    ),
-                ),
-            ),
-            errors = null,
+    override suspend fun getPersonBolk(fnrs: List<String>): GetPersonBolkResponse {
+        val token = texasHttpClient.systemToken(
+            "azuread",
+            TexasHttpClient.getTarget(scope)
+        ).accessToken
+
+        val request = GetPersonBolkRequest(
+            query = getPersonBolkQuery,
+            variables = GetPersonBolkVariables(identer = fnrs),
         )
+        try {
+            val response = httpClient
+                .post(pdlBaseUrl) {
+                    setBody(request)
+                    header(HttpHeaders.Authorization, "Bearer $token")
+                    header(PDL_BEHANDLINGSNUMMER_HEADER, BEHANDLINGSNUMMER_NARMESTELEDER)
+                    header(HttpHeaders.ContentType, "application/json")
+                }
+                .body<GetPersonBolkResponse>()
+            if (!response.errors.isNullOrEmpty()) {
+                logger.error("Error when requesting persons in bolk from PDL. Got errors: ${response.errors}")
+            }
+            return response
+        } catch (e: ResponseException) {
+            logger.error("Error on getPersonBolk query to PDL. Got status ${e.response.status} and message ${e.message}")
+            throw PdlRequestException("Error on getPersonBolk query to PDL", e)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.pdl.client
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -75,7 +76,7 @@ class PdlClient(
             val pdlReponse = httpClient
                 .post(pdlBaseUrl) {
                     setBody(getPersonRequest)
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearerAuth(token)
                     header(PDL_BEHANDLINGSNUMMER_HEADER, BEHANDLINGSNUMMER_NARMESTELEDER)
                     header(HttpHeaders.ContentType, "application/json")
                 }
@@ -102,7 +103,7 @@ class PdlClient(
             val response = httpClient
                 .post(pdlBaseUrl) {
                     setBody(request)
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                    bearerAuth(token)
                     header(PDL_BEHANDLINGSNUMMER_HEADER, BEHANDLINGSNUMMER_NARMESTELEDER)
                     header(HttpHeaders.ContentType, "application/json")
                 }

--- a/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/client/PdlClient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpHeaders
+import io.ktor.utils.io.CancellationException
 import no.nav.syfo.pdl.exception.PdlRequestException
 import no.nav.syfo.pdl.exception.PdlResourceNotFoundException
 import no.nav.syfo.texas.client.TexasHttpClient
@@ -88,9 +89,17 @@ class PdlClient(
                 throw PdlResourceNotFoundException("Did not find person in PDL for given fnr")
             }
             return pdlReponse
-        } catch (e: ResponseException) {
-            logger.error("Error on findPerson query to PDL. Got status ${e.response.status} and message ${e.message}")
-            throw PdlRequestException("Error on findPerson query to PDL", e)
+        } catch (e: Exception) {
+            when (e) {
+                is PdlResourceNotFoundException -> throw e
+                is CancellationException -> throw e
+                is ResponseException -> {
+                    logger.error("Error on findPerson query to PDL. Got status ${e.response.status} and message ${e.message}")
+                    throw PdlRequestException("Error on findPerson query to PDL", e)
+                }
+
+                else -> throw PdlRequestException("Error when calling PDL", e)
+            }
         }
     }
 
@@ -109,9 +118,16 @@ class PdlClient(
                 }
                 .body<GetPersonBolkResponse>()
             return response
-        } catch (e: ResponseException) {
-            logger.error("Error on getPersonBolk query to PDL. Got status ${e.response.status} and message ${e.message}")
-            throw PdlRequestException("Error on getPersonBolk query to PDL", e)
+        } catch (e: Exception) {
+            when (e) {
+                is CancellationException -> throw e
+                is ResponseException -> {
+                    logger.error("Error on getPersonBolk query to PDL. Got status ${e.response.status} and message ${e.message}")
+                    throw PdlRequestException("Error on getPersonBolk query to PDL", e)
+                }
+
+                else -> throw PdlRequestException("Error when calling PDL", e)
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/person/domain/PersonStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/person/domain/PersonStatus.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.person.domain
+
+enum class PersonStatus {
+    PENDING,
+    ENRICHED,
+    NOT_FOUND;
+
+    override fun toString(): String = name
+}

--- a/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
@@ -11,7 +11,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
-private const val PERSON_ENRICHMENT_BATCH_SIZE = 100
+private const val PERSON_ENRICHMENT_BATCH_SIZE = 500
 
 class PersonEnrichmentService(
     private val database: Database,

--- a/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
@@ -20,38 +20,42 @@ class PersonEnrichmentService(
     private val logger = LoggerFactory.getLogger(PersonEnrichmentService::class.java)
 
     suspend fun enrichPendingPersons() {
-        val pendingIdToFnr: Map<UUID, String> = transaction(database) {
-            PersonEntity
-                .find { PersonTable.status eq PersonStatus.PENDING.name }
-                .orderBy(PersonTable.created to SortOrder.ASC)
-                .limit(PERSON_ENRICHMENT_BATCH_SIZE)
-                .associate { it.id.value to it.fnr }
-        }
+        while (true) {
+            val pendingIdToFnr: Map<UUID, String> = transaction(database) {
+                PersonEntity
+                    .find { PersonTable.status eq PersonStatus.PENDING.name }
+                    .orderBy(PersonTable.created to SortOrder.ASC)
+                    .limit(PERSON_ENRICHMENT_BATCH_SIZE)
+                    .associate { it.id.value to it.fnr }
+            }
 
-        if (pendingIdToFnr.isEmpty()) return
+            if (pendingIdToFnr.isEmpty()) break
 
-        logger.info("Enriching ${pendingIdToFnr.size} pending persons from PDL")
+            logger.info("Enriching ${pendingIdToFnr.size} pending persons from PDL")
 
-        val pdlPersons = pdlService.getPersonsBolk(pendingIdToFnr.values.toList())
+            val pdlPersons = pdlService.getPersonsBolk(pendingIdToFnr.values.toList())
 
-        transaction(database) {
-            pendingIdToFnr.forEach { (id, fnr) ->
-                val entity = PersonEntity.findById(id) ?: return@forEach
-                val pdlPerson = pdlPersons[fnr]
-                if (pdlPerson != null) {
-                    entity.fornavn = pdlPerson.name.fornavn
-                    entity.mellomnavn = pdlPerson.name.mellomnavn
-                    entity.etternavn = pdlPerson.name.etternavn
-                    entity.foedselsdato = pdlPerson.foedselsdato?.foedselsdato
-                    entity.status = PersonStatus.ENRICHED.name
-                } else {
-                    entity.status = PersonStatus.NOT_FOUND.name
+            transaction(database) {
+                pendingIdToFnr.forEach { (id, fnr) ->
+                    val entity = PersonEntity.findById(id) ?: return@forEach
+                    val pdlPerson = pdlPersons[fnr]
+                    if (pdlPerson != null) {
+                        entity.fornavn = pdlPerson.name.fornavn
+                        entity.mellomnavn = pdlPerson.name.mellomnavn
+                        entity.etternavn = pdlPerson.name.etternavn
+                        entity.foedselsdato = pdlPerson.foedselsdato?.foedselsdato
+                        entity.status = PersonStatus.ENRICHED.name
+                    } else {
+                        entity.status = PersonStatus.NOT_FOUND.name
+                    }
                 }
             }
-        }
 
-        val enrichedCount = pdlPersons.values.count { it != null }
-        val notFoundCount = pendingIdToFnr.size - enrichedCount
-        logger.info("Enrichment done: $enrichedCount enriched, $notFoundCount not found")
+            val enrichedCount = pdlPersons.values.count { it != null }
+            val notFoundCount = pendingIdToFnr.size - enrichedCount
+            logger.info("Enrichment done: $enrichedCount enriched, $notFoundCount not found")
+
+            if (pendingIdToFnr.size < PERSON_ENRICHMENT_BATCH_SIZE) break
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
@@ -1,0 +1,57 @@
+package no.nav.syfo.person.service
+
+import no.nav.syfo.narmesteleder.exposed.PersonEntity
+import no.nav.syfo.narmesteleder.exposed.PersonTable
+import no.nav.syfo.pdl.PdlService
+import no.nav.syfo.person.domain.PersonStatus
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+private const val PERSON_ENRICHMENT_BATCH_SIZE = 100
+
+class PersonEnrichmentService(
+    private val database: Database,
+    private val pdlService: PdlService,
+) {
+    private val logger = LoggerFactory.getLogger(PersonEnrichmentService::class.java)
+
+    suspend fun enrichPendingPersons() {
+        val pendingIdToFnr: Map<UUID, String> = transaction(database) {
+            PersonEntity
+                .find { PersonTable.status eq PersonStatus.PENDING.name }
+                .orderBy(PersonTable.created to SortOrder.ASC)
+                .limit(PERSON_ENRICHMENT_BATCH_SIZE)
+                .associate { it.id.value to it.fnr }
+        }
+
+        if (pendingIdToFnr.isEmpty()) return
+
+        logger.info("Enriching ${pendingIdToFnr.size} pending persons from PDL")
+
+        val pdlPersons = pdlService.getPersonsBolk(pendingIdToFnr.values.toList())
+
+        transaction(database) {
+            pendingIdToFnr.forEach { (id, fnr) ->
+                val entity = PersonEntity.findById(id) ?: return@forEach
+                val pdlPerson = pdlPersons[fnr]
+                if (pdlPerson != null) {
+                    entity.fornavn = pdlPerson.name.fornavn
+                    entity.mellomnavn = pdlPerson.name.mellomnavn
+                    entity.etternavn = pdlPerson.name.etternavn
+                    entity.foedselsdato = pdlPerson.foedselsdato?.foedselsdato
+                    entity.status = PersonStatus.ENRICHED.name
+                } else {
+                    entity.status = PersonStatus.NOT_FOUND.name
+                }
+            }
+        }
+
+        val enrichedCount = pdlPersons.values.count { it != null }
+        val notFoundCount = pendingIdToFnr.size - enrichedCount
+        logger.info("Enrichment done: $enrichedCount enriched, $notFoundCount not found")
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
@@ -9,7 +9,6 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.slf4j.LoggerFactory
-import java.util.UUID
 
 private const val PERSON_ENRICHMENT_BATCH_SIZE = 500
 
@@ -21,24 +20,22 @@ class PersonEnrichmentService(
 
     suspend fun enrichPendingPersons() {
         while (true) {
-            val pendingIdToFnr: Map<UUID, String> = transaction(database) {
+            val personEntities = transaction(database) {
                 PersonEntity
                     .find { PersonTable.status eq PersonStatus.PENDING.name }
                     .orderBy(PersonTable.created to SortOrder.ASC)
-                    .limit(PERSON_ENRICHMENT_BATCH_SIZE)
-                    .associate { it.id.value to it.fnr }
+                    .limit(PERSON_ENRICHMENT_BATCH_SIZE).toSet()
             }
+            val pendingFnr = personEntities.map { it.fnr }
+            if (pendingFnr.isEmpty()) break
 
-            if (pendingIdToFnr.isEmpty()) break
+            logger.info("Enriching ${personEntities.size} pending persons from PDL")
 
-            logger.info("Enriching ${pendingIdToFnr.size} pending persons from PDL")
-
-            val pdlPersons = pdlService.getPersonsBolk(pendingIdToFnr.values.toList())
+            val pdlPersons = pdlService.getPersonsBolk(pendingFnr)
 
             transaction(database) {
-                pendingIdToFnr.forEach { (id, fnr) ->
-                    val entity = PersonEntity.findById(id) ?: return@forEach
-                    val pdlPerson = pdlPersons[fnr]
+                personEntities.forEach { entity ->
+                    val pdlPerson = pdlPersons[entity.fnr]
                     if (pdlPerson != null) {
                         entity.fornavn = pdlPerson.name.fornavn
                         entity.mellomnavn = pdlPerson.name.mellomnavn
@@ -52,10 +49,10 @@ class PersonEnrichmentService(
             }
 
             val enrichedCount = pdlPersons.values.count { it != null }
-            val notFoundCount = pendingIdToFnr.size - enrichedCount
+            val notFoundCount = pendingFnr.size - enrichedCount
             logger.info("Enrichment done: $enrichedCount enriched, $notFoundCount not found")
 
-            if (pendingIdToFnr.size < PERSON_ENRICHMENT_BATCH_SIZE) break
+            if (pendingFnr.size < PERSON_ENRICHMENT_BATCH_SIZE) break
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/service/PersonEnrichmentService.kt
@@ -32,25 +32,40 @@ class PersonEnrichmentService(
             logger.info("Enriching ${personEntities.size} pending persons from PDL")
 
             val pdlPersons = pdlService.getPersonsBolk(pendingFnr)
-
+            var enrichedCount = 0
+            var notFoundCount = 0
             transaction(database) {
                 personEntities.forEach { entity ->
                     val pdlPerson = pdlPersons[entity.fnr]
-                    if (pdlPerson != null) {
-                        entity.fornavn = pdlPerson.name.fornavn
-                        entity.mellomnavn = pdlPerson.name.mellomnavn
-                        entity.etternavn = pdlPerson.name.etternavn
-                        entity.foedselsdato = pdlPerson.foedselsdato?.foedselsdato
-                        entity.status = PersonStatus.ENRICHED.name
-                    } else {
-                        entity.status = PersonStatus.NOT_FOUND.name
+                    when {
+                        pdlPerson != null -> {
+                            entity.fornavn = pdlPerson.name.fornavn
+                            entity.mellomnavn = pdlPerson.name.mellomnavn
+                            entity.etternavn = pdlPerson.name.etternavn
+                            entity.foedselsdato = pdlPerson.foedselsdato?.foedselsdato
+                            entity.status = PersonStatus.ENRICHED.name
+                            enrichedCount++
+                        }
+
+                        pdlPersons.containsKey(entity.fnr) -> {
+                            entity.status = PersonStatus.NOT_FOUND.name
+                            notFoundCount++
+                        }
+
+                        else -> {
+                        }
                     }
                 }
             }
 
-            val enrichedCount = pdlPersons.values.count { it != null }
-            val notFoundCount = pendingFnr.size - enrichedCount
-            logger.info("Enrichment done: $enrichedCount enriched, $notFoundCount not found")
+            val updatedCount = enrichedCount + notFoundCount
+            val unchangedCount = pendingFnr.size - updatedCount
+            logger.info("Enrichment done: $enrichedCount enriched, $notFoundCount not found, $unchangedCount unchanged")
+
+            if (updatedCount == 0) {
+                logger.warn("Stopping person enrichment because the current batch did not update any pending persons")
+                break
+            }
 
             if (pendingFnr.size < PERSON_ENRICHMENT_BATCH_SIZE) break
         }

--- a/src/main/kotlin/no/nav/syfo/person/task/PersonEnrichmentTask.kt
+++ b/src/main/kotlin/no/nav/syfo/person/task/PersonEnrichmentTask.kt
@@ -1,0 +1,17 @@
+package no.nav.syfo.person.task
+
+import no.nav.syfo.application.task.ScheduledLeaderTask
+import no.nav.syfo.person.service.PersonEnrichmentService
+import kotlin.time.Duration
+
+class PersonEnrichmentTask(
+    private val personEnrichmentService: PersonEnrichmentService,
+    pollingInterval: Duration,
+) : ScheduledLeaderTask(
+    name = PersonEnrichmentTask::class.qualifiedName!!,
+    interval = pollingInterval,
+) {
+    override suspend fun execute() {
+        personEnrichmentService.enrichPendingPersons()
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.application.environment.Environment
 import no.nav.syfo.application.events.LeaderChange
 import no.nav.syfo.application.events.LeaderChangeEvent
 import no.nav.syfo.narmesteleder.task.BehovMaintenanceTask
+import no.nav.syfo.person.task.PersonEnrichmentTask
 import no.nav.syfo.util.logger
 import org.koin.ktor.ext.inject
 import java.util.Collections
@@ -27,6 +28,7 @@ fun Application.configureBackgroundTasks() {
     val sendDialogTask by inject<SendDialogTask>()
     val updateDialogTask by inject<UpdateDialogTask>()
     val behovMaintenanceTask by inject<BehovMaintenanceTask>()
+    val personEnrichmentTask by inject<PersonEnrichmentTask>()
 
     val taskJobs: MutableList<Job> = Collections.synchronizedList(mutableListOf())
 
@@ -44,6 +46,9 @@ fun Application.configureBackgroundTasks() {
                         jobs += launch { behovMaintenanceTask.runTask() }
                     } else {
                         logger.info("Maintenance task is NOT enabled. Skipping behovMaintenanceTask.")
+                    }
+                    if (environment.otherProperties.personEnrichmentTaskEnabled) {
+                        jobs += launch { personEnrichmentTask.runTask() }
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -55,6 +55,8 @@ import no.nav.syfo.narmesteleder.task.BehovMaintenanceTask
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.pdl.client.FakePdlClient
 import no.nav.syfo.pdl.client.PdlClient
+import no.nav.syfo.person.service.PersonEnrichmentService
+import no.nav.syfo.person.task.PersonEnrichmentTask
 import no.nav.syfo.sykmelding.db.ISykmeldingDb
 import no.nav.syfo.sykmelding.db.SykmeldingDb
 import no.nav.syfo.sykmelding.exposed.IActiveSykmeldingRepository
@@ -301,6 +303,7 @@ private fun servicesModule() = module {
             eregCache = get()
         )
     }
+    single { PersonEnrichmentService(database = get(), pdlService = get()) }
 }
 
 private fun tasksModule() = module {
@@ -314,6 +317,10 @@ private fun tasksModule() = module {
     single {
         val pollingInterval = Duration.parse(env().otherProperties.updateDialogportenTaskProperties.pollingDelay)
         UpdateDialogTask(get(), pollingInterval)
+    }
+    single {
+        val pollingInterval = Duration.parse(env().otherProperties.personEnrichmentTaskDelay)
+        PersonEnrichmentTask(get(), pollingInterval)
     }
 }
 

--- a/src/main/resources/graphql/hentPersonBolk.graphql
+++ b/src/main/resources/graphql/hentPersonBolk.graphql
@@ -6,9 +6,9 @@ query($identer: [ID!]!){
                 fornavn
                 mellomnavn
                 etternavn
-            }
+            },
+            foedselsdato { foedselsdato }
         },
-        foedselsdato { foedselsdato }
         code
     },
     hentIdenterBolk(identer: $identer, historikk: false) {

--- a/src/main/resources/graphql/hentPersonBolk.graphql
+++ b/src/main/resources/graphql/hentPersonBolk.graphql
@@ -1,0 +1,22 @@
+query($identer: [ID!]!){
+    hentPersonBolk(identer: $identer) {
+        ident,
+        person {
+            navn(historikk: false) {
+                fornavn
+                mellomnavn
+                etternavn
+            }
+        },
+        foedselsdato { foedselsdato }
+        code
+    },
+    hentIdenterBolk(identer: $identer, historikk: false) {
+        ident,
+        identer {
+            ident,
+            gruppe
+        },
+        code
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/dialogporten/service/DialogportenServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogporten/service/DialogportenServiceTest.kt
@@ -69,6 +69,8 @@ class DialogportenServiceTest :
                         maintenanceTaskDelay = "1s",
                         maintenanceTaskEnabled = true,
                         persistNarmestelederRegister = false,
+                        personEnrichmentTaskDelay = "5m",
+                        personEnrichmentTaskEnabled = false,
                     ),
                     pdlService = pdlService,
                 )

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederRegisterServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederRegisterServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.narmesteleder.exposed.PersonEntity
 import no.nav.syfo.narmesteleder.exposed.PersonTable
 import no.nav.syfo.narmesteleder.exposed.personTable
 import no.nav.syfo.narmesteleder.kafka.LeesahNarmestelederRecord
+import no.nav.syfo.person.domain.PersonStatus
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -282,7 +283,7 @@ class NarmestelederRegisterServiceTest :
                             "12345678901"
                         ).sorted()
                     }
-                    insertedPerson.status shouldBe "PENDING"
+                    insertedPerson.status shouldBe PersonStatus.PENDING.name
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTaskTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/task/BehovMaintenanceTaskTest.kt
@@ -31,7 +31,9 @@ class BehovMaintenanceTaskTest :
             maintenanceTaskDelay = "100ms",
             persistSendtSykmelding = true,
             maintenanceTaskEnabled = true,
-            persistNarmestelederRegister = false
+            persistNarmestelederRegister = false,
+            personEnrichmentTaskDelay = "5m",
+            personEnrichmentTaskEnabled = false,
         )
 
         fun createTask() = BehovMaintenanceTask(

--- a/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
@@ -9,15 +9,21 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.valkey.PdlCache
+import no.nav.syfo.pdl.client.GetPersonBolkResponse
 import no.nav.syfo.pdl.client.GetPersonResponse
+import no.nav.syfo.pdl.client.HentIdenterBolk
+import no.nav.syfo.pdl.client.HentPersonBolk
 import no.nav.syfo.pdl.client.IPdlClient
 import no.nav.syfo.pdl.client.Ident
 import no.nav.syfo.pdl.client.IdentResponse
 import no.nav.syfo.pdl.client.Navn
+import no.nav.syfo.pdl.client.PdlIdent
+import no.nav.syfo.pdl.client.PersonBolkResponseData
 import no.nav.syfo.pdl.client.PersonResponse
 import no.nav.syfo.pdl.client.ResponseData
 import no.nav.syfo.pdl.exception.PdlRequestException
 import no.nav.syfo.pdl.exception.PdlResourceNotFoundException
+import no.nav.syfo.pdl.client.Person as PdlClientPerson
 
 class PdlServiceTest :
     DescribeSpec({
@@ -143,6 +149,87 @@ class PdlServiceTest :
                 }
 
                 coVerify(exactly = 1) { pdlClient.getPerson(fnr) }
+            }
+        }
+
+        describe("getPersonsBolk") {
+            fun bolkResponse(vararg entries: Triple<String, PdlClientPerson?, String>) = GetPersonBolkResponse(
+                data = PersonBolkResponseData(
+                    hentPersonBolk = entries.map { (ident, person, code) ->
+                        HentPersonBolk(ident = ident, person = person, code = code)
+                    },
+                    hentIdenterBolk = entries.map { (ident, _, _) ->
+                        HentIdenterBolk(
+                            ident = ident,
+                            identer = listOf(PdlIdent(ident = ident, gruppe = "FOLKEREGISTERIDENT")),
+                            code = "ok",
+                        )
+                    },
+                ),
+                errors = null,
+            )
+
+            it("should return map with Person when bolk returns code ok") {
+                val fnr = "12345678901"
+                val navn = Navn(fornavn = "Test", mellomnavn = null, etternavn = "Person")
+
+                coEvery { pdlClient.getPersonBolk(listOf(fnr)) } returns
+                    bolkResponse(Triple(fnr, PdlClientPerson(navn = listOf(navn)), "ok"))
+
+                val result = pdlService.getPersonsBolk(listOf(fnr))
+
+                result[fnr]?.name shouldBe navn
+                result[fnr]?.nationalIdentificationNumber shouldBe fnr
+                coVerify(exactly = 1) { pdlClient.getPersonBolk(listOf(fnr)) }
+            }
+
+            it("should return null in map when bolk code is not ok") {
+                val fnr = "12345678901"
+
+                coEvery { pdlClient.getPersonBolk(listOf(fnr)) } returns
+                    bolkResponse(Triple(fnr, null, "not_found"))
+
+                val result = pdlService.getPersonsBolk(listOf(fnr))
+
+                result[fnr] shouldBe null
+            }
+
+            it("should return null in map when person is null despite ok code") {
+                val fnr = "12345678901"
+
+                coEvery { pdlClient.getPersonBolk(listOf(fnr)) } returns
+                    bolkResponse(Triple(fnr, null, "ok"))
+
+                val result = pdlService.getPersonsBolk(listOf(fnr))
+
+                result[fnr] shouldBe null
+            }
+
+            it("should return map with multiple entries") {
+                val fnr1 = "12345678901"
+                val fnr2 = "98765432109"
+                val navn1 = Navn(fornavn = "Ola", mellomnavn = null, etternavn = "Nordmann")
+
+                coEvery { pdlClient.getPersonBolk(listOf(fnr1, fnr2)) } returns
+                    bolkResponse(
+                        Triple(fnr1, PdlClientPerson(navn = listOf(navn1)), "ok"),
+                        Triple(fnr2, null, "not_found"),
+                    )
+
+                val result = pdlService.getPersonsBolk(listOf(fnr1, fnr2))
+
+                result[fnr1]?.name shouldBe navn1
+                result[fnr2] shouldBe null
+            }
+
+            it("should throw PdlRequestException when client throws") {
+                val fnrs = listOf("12345678901")
+
+                coEvery { pdlClient.getPersonBolk(fnrs) } throws PdlRequestException("PDL error")
+
+                shouldThrow<PdlRequestException> {
+                    pdlService.getPersonsBolk(fnrs)
+                }
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
@@ -153,6 +153,7 @@ class PdlServiceTest :
         }
 
         describe("getPersonsBolk") {
+            val token = "token"
             fun bolkResponse(vararg entries: Triple<String, PdlClientPerson?, String>) = GetPersonBolkResponse(
                 data = PersonBolkResponseData(
                     hentPersonBolk = entries.map { (ident, person, code) ->
@@ -173,20 +174,23 @@ class PdlServiceTest :
                 val fnr = "12345678901"
                 val navn = Navn(fornavn = "Test", mellomnavn = null, etternavn = "Person")
 
-                coEvery { pdlClient.getPersonBolk(listOf(fnr)) } returns
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(listOf(fnr), token) } returns
                     bolkResponse(Triple(fnr, PdlClientPerson(navn = listOf(navn)), "ok"))
 
                 val result = pdlService.getPersonsBolk(listOf(fnr))
 
                 result[fnr]?.name shouldBe navn
                 result[fnr]?.nationalIdentificationNumber shouldBe fnr
-                coVerify(exactly = 1) { pdlClient.getPersonBolk(listOf(fnr)) }
+                coVerify(exactly = 1) { pdlClient.getSystemToken() }
+                coVerify(exactly = 1) { pdlClient.getPersonBolk(listOf(fnr), token) }
             }
 
             it("should return null in map when bolk code is not ok") {
                 val fnr = "12345678901"
 
-                coEvery { pdlClient.getPersonBolk(listOf(fnr)) } returns
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(listOf(fnr), token) } returns
                     bolkResponse(Triple(fnr, null, "not_found"))
 
                 val result = pdlService.getPersonsBolk(listOf(fnr))
@@ -197,7 +201,8 @@ class PdlServiceTest :
             it("should return null in map when person is null despite ok code") {
                 val fnr = "12345678901"
 
-                coEvery { pdlClient.getPersonBolk(listOf(fnr)) } returns
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(listOf(fnr), token) } returns
                     bolkResponse(Triple(fnr, null, "ok"))
 
                 val result = pdlService.getPersonsBolk(listOf(fnr))
@@ -210,7 +215,8 @@ class PdlServiceTest :
                 val fnr2 = "98765432109"
                 val navn1 = Navn(fornavn = "Ola", mellomnavn = null, etternavn = "Nordmann")
 
-                coEvery { pdlClient.getPersonBolk(listOf(fnr1, fnr2)) } returns
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(listOf(fnr1, fnr2), token) } returns
                     bolkResponse(
                         Triple(fnr1, PdlClientPerson(navn = listOf(navn1)), "ok"),
                         Triple(fnr2, null, "not_found"),
@@ -225,11 +231,33 @@ class PdlServiceTest :
             it("should throw PdlRequestException when client throws") {
                 val fnrs = listOf("12345678901")
 
-                coEvery { pdlClient.getPersonBolk(fnrs) } throws PdlRequestException("PDL error")
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(fnrs, token) } throws PdlRequestException("PDL error")
 
                 shouldThrow<PdlRequestException> {
                     pdlService.getPersonsBolk(fnrs)
                 }
+            }
+
+            it("should fetch token once and chunk fnrs in groups of 100") {
+                val fnrs = (1..201).map { it.toString().padStart(11, '0') }
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(any<List<String>>(), token) } answers {
+                    val chunk = firstArg<List<String>>()
+                    bolkResponse(*chunk.map { Triple(it, null, "not_found") }.toTypedArray())
+                }
+
+                pdlService.getPersonsBolk(fnrs)
+
+                coVerify(exactly = 1) { pdlClient.getSystemToken() }
+                coVerify(exactly = 2) { pdlClient.getPersonBolk(match { it.size == 100 }, token) }
+                coVerify(exactly = 1) { pdlClient.getPersonBolk(match { it.size == 1 }, token) }
+            }
+
+            it("should return empty map when fnr-list is empty") {
+                pdlService.getPersonsBolk(emptyList()) shouldBe emptyMap()
+
+                coVerify(exactly = 0) { pdlClient.getSystemToken() }
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/PdlServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.application.valkey.PdlCache
 import no.nav.syfo.pdl.client.GetPersonBolkResponse
@@ -228,13 +229,53 @@ class PdlServiceTest :
                 result[fnr2] shouldBe null
             }
 
-            it("should throw PdlRequestException when client throws") {
+            it("should keep successful chunk results when another chunk fails") {
+                val failedChunkFnrs = (1..100).map { it.toString().padStart(11, '0') }
+                val successfulFnr = "90000000001"
+                val notFoundFnr = "90000000002"
+                val successfulChunkFnrs = listOf(successfulFnr, notFoundFnr)
+                val fnrs = failedChunkFnrs + successfulChunkFnrs
+                val navn = Navn(fornavn = "Test", mellomnavn = null, etternavn = "Person")
+
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(failedChunkFnrs, token) } throws PdlRequestException("PDL error")
+                coEvery { pdlClient.getPersonBolk(successfulChunkFnrs, token) } returns
+                    bolkResponse(
+                        Triple(successfulFnr, PdlClientPerson(navn = listOf(navn)), "ok"),
+                        Triple(notFoundFnr, null, "not_found"),
+                    )
+
+                val result = pdlService.getPersonsBolk(fnrs)
+
+                result.size shouldBe 2
+                result[successfulFnr]?.name shouldBe navn
+                result[successfulFnr]?.nationalIdentificationNumber shouldBe successfulFnr
+                result.containsKey(notFoundFnr) shouldBe true
+                result[notFoundFnr] shouldBe null
+                failedChunkFnrs.any { result.containsKey(it) } shouldBe false
+            }
+
+            it("should return empty map when all chunks fail with PdlRequestException") {
+                val firstChunkFnrs = (1..100).map { it.toString().padStart(11, '0') }
+                val secondChunkFnrs = listOf("90000000001")
+                val fnrs = firstChunkFnrs + secondChunkFnrs
+
+                coEvery { pdlClient.getSystemToken() } returns token
+                coEvery { pdlClient.getPersonBolk(firstChunkFnrs, token) } throws PdlRequestException("PDL error")
+                coEvery { pdlClient.getPersonBolk(secondChunkFnrs, token) } throws PdlRequestException("PDL error")
+
+                val result = pdlService.getPersonsBolk(fnrs)
+
+                result shouldBe emptyMap()
+            }
+
+            it("should rethrow CancellationException when chunk fetch is cancelled") {
                 val fnrs = listOf("12345678901")
 
                 coEvery { pdlClient.getSystemToken() } returns token
-                coEvery { pdlClient.getPersonBolk(fnrs, token) } throws PdlRequestException("PDL error")
+                coEvery { pdlClient.getPersonBolk(fnrs, token) } throws CancellationException("cancelled")
 
-                shouldThrow<PdlRequestException> {
+                shouldThrow<CancellationException> {
                     pdlService.getPersonsBolk(fnrs)
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/pdl/client/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/client/PdlClientTest.kt
@@ -146,4 +146,87 @@ class PdlClientTest :
                 shouldThrow<PdlRequestException> { client.getPerson(fnr) }
             }
         }
+
+        describe("getPersonBolk") {
+            it("should return GetPersonBolkResponse when getPersonBolk responds with 200") {
+                val fnr1 = "12345678901"
+                val fnr2 = "98765432109"
+                val responseJson = """
+                {
+                  "data": {
+                    "hentPersonBolk": [
+                      {
+                        "ident": "$fnr1",
+                        "person": {
+                          "navn": [{"fornavn": "Ola", "mellomnavn": null, "etternavn": "Nordmann"}],
+                          "foedselsdato": []
+                        },
+                        "code": "ok"
+                      },
+                      {
+                        "ident": "$fnr2",
+                        "person": null,
+                        "code": "not_found"
+                      }
+                    ],
+                    "hentIdenterBolk": [
+                      {
+                        "ident": "$fnr1",
+                        "identer": [{"ident": "$fnr1", "gruppe": "FOLKEREGISTERIDENT"}],
+                        "code": "ok"
+                      },
+                      {
+                        "ident": "$fnr2",
+                        "identer": null,
+                        "code": "not_found"
+                      }
+                    ]
+                  }
+                }
+                """.trimIndent()
+                val mockEngine = getMockEngine(
+                    status = HttpStatusCode.OK,
+                    headers = Headers.build { append("Content-Type", "application/json") },
+                    content = responseJson,
+                )
+                coEvery {
+                    mockTexasClient.systemToken(any(), any())
+                } returns TexasResponse("token", 111, "tokenType")
+                val client = PdlClient(httpClientDefault(HttpClient(mockEngine)), "", mockTexasClient, "scope")
+
+                val result = client.getPersonBolk(listOf(fnr1, fnr2))
+
+                result.data?.hentPersonBolk?.find { it.ident == fnr1 }?.person?.navn?.firstOrNull()?.fornavn shouldBe "Ola"
+                result.data?.hentPersonBolk?.find { it.ident == fnr2 }?.code shouldBe "not_found"
+                result.data?.hentPersonBolk?.find { it.ident == fnr2 }?.person shouldBe null
+            }
+
+            it("should throw PdlRequestException when getPersonBolk responds with 4xx") {
+                val mockEngine = getMockEngine(
+                    status = HttpStatusCode.BadRequest,
+                    headers = Headers.build { append("Content-Type", "application/json") },
+                    content = "invalid request",
+                )
+                coEvery {
+                    mockTexasClient.systemToken(any(), any())
+                } returns TexasResponse("token", 111, "tokenType")
+                val client = PdlClient(httpClientDefault(HttpClient(mockEngine)), "", mockTexasClient, "scope")
+
+                shouldThrow<PdlRequestException> { client.getPersonBolk(listOf("12345678901")) }
+            }
+
+            it("should throw PdlRequestException when getPersonBolk responds with 5xx") {
+                val mockEngine = getMockEngine(
+                    status = HttpStatusCode.ServiceUnavailable,
+                    headers = Headers.build { append("Content-Type", "application/json") },
+                    content = "error",
+                )
+                coEvery {
+                    mockTexasClient.systemToken(any(), any())
+                } returns TexasResponse("token", 111, "tokenType")
+                val client = PdlClient(httpClientDefault(HttpClient(mockEngine)), "", mockTexasClient, "scope")
+
+                shouldThrow<PdlRequestException> { client.getPersonBolk(listOf("12345678901")) }
+            }
+        }
     })

--- a/src/test/kotlin/no/nav/syfo/pdl/client/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/client/PdlClientTest.kt
@@ -9,6 +9,7 @@ import io.ktor.http.Headers
 import io.ktor.http.HttpStatusCode
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.pdl.exception.PdlRequestException
 import no.nav.syfo.pdl.exception.PdlResourceNotFoundException
@@ -194,7 +195,7 @@ class PdlClientTest :
                 } returns TexasResponse("token", 111, "tokenType")
                 val client = PdlClient(httpClientDefault(HttpClient(mockEngine)), "", mockTexasClient, "scope")
 
-                val result = client.getPersonBolk(listOf(fnr1, fnr2))
+                val result = client.getPersonBolk(listOf(fnr1, fnr2), "provided-token")
 
                 result.data?.hentPersonBolk?.find { it.ident == fnr1 }?.person?.navn?.firstOrNull()?.fornavn shouldBe "Ola"
                 result.data?.hentPersonBolk?.find { it.ident == fnr2 }?.code shouldBe "not_found"
@@ -212,7 +213,7 @@ class PdlClientTest :
                 } returns TexasResponse("token", 111, "tokenType")
                 val client = PdlClient(httpClientDefault(HttpClient(mockEngine)), "", mockTexasClient, "scope")
 
-                shouldThrow<PdlRequestException> { client.getPersonBolk(listOf("12345678901")) }
+                shouldThrow<PdlRequestException> { client.getPersonBolk(listOf("12345678901"), "provided-token") }
             }
 
             it("should throw PdlRequestException when getPersonBolk responds with 5xx") {
@@ -226,7 +227,35 @@ class PdlClientTest :
                 } returns TexasResponse("token", 111, "tokenType")
                 val client = PdlClient(httpClientDefault(HttpClient(mockEngine)), "", mockTexasClient, "scope")
 
-                shouldThrow<PdlRequestException> { client.getPersonBolk(listOf("12345678901")) }
+                shouldThrow<PdlRequestException> { client.getPersonBolk(listOf("12345678901"), "provided-token") }
+            }
+
+            it("should use provided token in overload without fetching system token") {
+                val fnr = "12345678901"
+                val responseJson = """
+                {
+                  "data": {
+                    "hentPersonBolk": [
+                      {
+                        "ident": "$fnr",
+                        "person": null,
+                        "code": "not_found"
+                      }
+                    ],
+                    "hentIdenterBolk": []
+                  }
+                }
+                """.trimIndent()
+                val mockEngine = getMockEngine(
+                    status = HttpStatusCode.OK,
+                    headers = Headers.build { append("Content-Type", "application/json") },
+                    content = responseJson,
+                )
+                val client = PdlClient(httpClientDefault(HttpClient(mockEngine)), "", mockTexasClient, "scope")
+
+                client.getPersonBolk(listOf(fnr), "provided-token")
+
+                coVerify(exactly = 0) { mockTexasClient.systemToken(any(), any()) }
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/pdl/client/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/client/PdlClientTest.kt
@@ -74,7 +74,7 @@ class PdlClientTest :
                 result.data?.identer?.identer?.firstOrNull()?.ident shouldBe fnr
             }
 
-            it("should throw exception when response contains error") {
+            it("should throw PdlResourceNotFoundException when response contains error") {
                 val fnr = "12345678901"
                 val getPersonResponse = """
                 {

--- a/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
@@ -1,0 +1,149 @@
+package no.nav.syfo.person.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.syfo.TestDB
+import no.nav.syfo.narmesteleder.exposed.PersonBatchInsertRow
+import no.nav.syfo.narmesteleder.exposed.PersonEntity
+import no.nav.syfo.narmesteleder.exposed.PersonTable
+import no.nav.syfo.narmesteleder.exposed.personTable
+import no.nav.syfo.pdl.PdlService
+import no.nav.syfo.pdl.Person
+import no.nav.syfo.pdl.client.Foedselsdato
+import no.nav.syfo.pdl.client.Navn
+import no.nav.syfo.person.domain.PersonStatus
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.LocalDate
+
+class PersonEnrichmentServiceTest :
+    DescribeSpec({
+        val pdlService = mockk<PdlService>()
+
+        beforeTest {
+            clearAllMocks()
+            TestDB.clearPersonData()
+        }
+
+        fun insertPerson(fnr: String, status: PersonStatus) {
+            transaction(TestDB.exposedDatabase) {
+                personTable.batchInsertIgnoreExisting(
+                    listOf(PersonBatchInsertRow(fnr = fnr, status = status.name)),
+                )
+            }
+        }
+
+        fun findPerson(fnr: String): PersonEntity? = transaction(TestDB.exposedDatabase) {
+            PersonEntity.find { PersonTable.fnr eq fnr }.firstOrNull()
+        }
+
+        fun service() = PersonEnrichmentService(
+            database = TestDB.exposedDatabase,
+            pdlService = pdlService,
+        )
+
+        describe("enrichPendingPersons") {
+            it("should do nothing when there are no pending persons") {
+                coEvery { pdlService.getPersonsBolk(any()) } returns emptyMap()
+
+                service().enrichPendingPersons()
+
+                coVerify(exactly = 0) { pdlService.getPersonsBolk(any()) }
+            }
+
+            it("should enrich a pending person found in PDL") {
+                val fnr = "12345678901"
+                insertPerson(fnr, PersonStatus.PENDING)
+
+                val navn = Navn(fornavn = "Ola", mellomnavn = null, etternavn = "Nordmann")
+                val foedselsdato = LocalDate.of(1990, 1, 15)
+                coEvery { pdlService.getPersonsBolk(listOf(fnr)) } returns mapOf(
+                    fnr to Person(
+                        name = navn,
+                        nationalIdentificationNumber = fnr,
+                        foedselsdato = Foedselsdato(foedselsdato),
+                    ),
+                )
+
+                service().enrichPendingPersons()
+
+                val updated = findPerson(fnr)
+                updated?.fornavn shouldBe "Ola"
+                updated?.mellomnavn shouldBe null
+                updated?.etternavn shouldBe "Nordmann"
+                updated?.foedselsdato shouldBe foedselsdato
+                updated?.status shouldBe PersonStatus.ENRICHED.name
+            }
+
+            it("should set NOT_FOUND when PDL returns null for fnr") {
+                val fnr = "12345678901"
+                insertPerson(fnr, PersonStatus.PENDING)
+
+                coEvery { pdlService.getPersonsBolk(listOf(fnr)) } returns mapOf(fnr to null)
+
+                service().enrichPendingPersons()
+
+                val updated = findPerson(fnr)
+                updated?.status shouldBe PersonStatus.NOT_FOUND.name
+                updated?.fornavn shouldBe null
+            }
+
+            it("should handle mix of found and not-found persons") {
+                val fnr1 = "12345678901"
+                val fnr2 = "98765432109"
+                insertPerson(fnr1, PersonStatus.PENDING)
+                insertPerson(fnr2, PersonStatus.PENDING)
+
+                val navn1 = Navn(fornavn = "Kari", mellomnavn = "Marte", etternavn = "Nordmann")
+                coEvery { pdlService.getPersonsBolk(any()) } returns mapOf(
+                    fnr1 to Person(
+                        name = navn1,
+                        nationalIdentificationNumber = fnr1,
+                        foedselsdato = null,
+                    ),
+                    fnr2 to null,
+                )
+
+                service().enrichPendingPersons()
+
+                val person1 = findPerson(fnr1)
+                person1?.fornavn shouldBe "Kari"
+                person1?.mellomnavn shouldBe "Marte"
+                person1?.etternavn shouldBe "Nordmann"
+                person1?.status shouldBe PersonStatus.ENRICHED.name
+
+                val person2 = findPerson(fnr2)
+                person2?.status shouldBe PersonStatus.NOT_FOUND.name
+            }
+
+            it("should not process persons with status other than PENDING") {
+                val fnrEnriched = "12345678901"
+                val fnrNotFound = "98765432109"
+                insertPerson(fnrEnriched, PersonStatus.ENRICHED)
+                insertPerson(fnrNotFound, PersonStatus.NOT_FOUND)
+
+                service().enrichPendingPersons()
+
+                coVerify(exactly = 0) { pdlService.getPersonsBolk(any()) }
+            }
+
+            it("should only process up to 100 pending persons per run") {
+                val fnrs = (1..101).map { i -> i.toString().padStart(11, '0') }
+                fnrs.forEach { insertPerson(it, PersonStatus.PENDING) }
+
+                coEvery { pdlService.getPersonsBolk(any()) } returns emptyMap()
+
+                service().enrichPendingPersons()
+
+                coVerify(exactly = 1) {
+                    pdlService.getPersonsBolk(
+                        match { it.size == 100 },
+                    )
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
@@ -41,6 +41,16 @@ class PersonEnrichmentServiceTest :
             PersonEntity.find { PersonTable.fnr eq fnr }.firstOrNull()
         }
 
+        fun countPersons(status: PersonStatus): Long = transaction(TestDB.exposedDatabase) {
+            PersonEntity.find { PersonTable.status eq status.name }.count()
+        }
+
+        fun createPdlPerson(fnr: String, fornavn: String = "Ola") = Person(
+            name = Navn(fornavn = fornavn, mellomnavn = null, etternavn = "Nordmann"),
+            nationalIdentificationNumber = fnr,
+            foedselsdato = null,
+        )
+
         fun service() = PersonEnrichmentService(
             database = TestDB.exposedDatabase,
             pdlService = pdlService,
@@ -131,11 +141,29 @@ class PersonEnrichmentServiceTest :
                 coVerify(exactly = 0) { pdlService.getPersonsBolk(any()) }
             }
 
-            it("should process batches continuously until fewer than batch size persons remain") {
-                val fnrs = (1..501).map { i -> i.toString().padStart(11, '0') }
+            it("should stop when a batch does not update any pending persons") {
+                val fnrs = (1..500).map { i -> i.toString().padStart(11, '0') }
                 fnrs.forEach { insertPerson(it, PersonStatus.PENDING) }
 
                 coEvery { pdlService.getPersonsBolk(any()) } returns emptyMap()
+
+                service().enrichPendingPersons()
+
+                countPersons(PersonStatus.PENDING) shouldBe 500L
+                countPersons(PersonStatus.NOT_FOUND) shouldBe 0L
+                countPersons(PersonStatus.ENRICHED) shouldBe 0L
+                coVerify(exactly = 1) {
+                    pdlService.getPersonsBolk(match { it.size == 500 })
+                }
+            }
+
+            it("should process batches continuously while each batch makes progress") {
+                val fnrs = (1..501).map { i -> i.toString().padStart(11, '0') }
+                fnrs.forEach { insertPerson(it, PersonStatus.PENDING) }
+
+                coEvery { pdlService.getPersonsBolk(any()) } coAnswers {
+                    firstArg<List<String>>().associateWith { fnr -> createPdlPerson(fnr) }
+                }
 
                 service().enrichPendingPersons()
 
@@ -145,6 +173,7 @@ class PersonEnrichmentServiceTest :
                 coVerify(exactly = 1) {
                     pdlService.getPersonsBolk(match { it.size == 1 })
                 }
+                countPersons(PersonStatus.ENRICHED) shouldBe 501L
             }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
@@ -131,7 +131,7 @@ class PersonEnrichmentServiceTest :
                 coVerify(exactly = 0) { pdlService.getPersonsBolk(any()) }
             }
 
-            it("should only process up to 100 pending persons per run") {
+            it("should process batches continuously until fewer than batch size persons remain") {
                 val fnrs = (1..101).map { i -> i.toString().padStart(11, '0') }
                 fnrs.forEach { insertPerson(it, PersonStatus.PENDING) }
 
@@ -140,9 +140,10 @@ class PersonEnrichmentServiceTest :
                 service().enrichPendingPersons()
 
                 coVerify(exactly = 1) {
-                    pdlService.getPersonsBolk(
-                        match { it.size == 100 },
-                    )
+                    pdlService.getPersonsBolk(match { it.size == 100 })
+                }
+                coVerify(exactly = 1) {
+                    pdlService.getPersonsBolk(match { it.size == 1 })
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/service/PersonEnrichmentServiceTest.kt
@@ -132,7 +132,7 @@ class PersonEnrichmentServiceTest :
             }
 
             it("should process batches continuously until fewer than batch size persons remain") {
-                val fnrs = (1..101).map { i -> i.toString().padStart(11, '0') }
+                val fnrs = (1..501).map { i -> i.toString().padStart(11, '0') }
                 fnrs.forEach { insertPerson(it, PersonStatus.PENDING) }
 
                 coEvery { pdlService.getPersonsBolk(any()) } returns emptyMap()
@@ -140,7 +140,7 @@ class PersonEnrichmentServiceTest :
                 service().enrichPendingPersons()
 
                 coVerify(exactly = 1) {
-                    pdlService.getPersonsBolk(match { it.size == 100 })
+                    pdlService.getPersonsBolk(match { it.size == 500 })
                 }
                 coVerify(exactly = 1) {
                     pdlService.getPersonsBolk(match { it.size == 1 })


### PR DESCRIPTION
## Beskrivelse

Beriker person-tabellen med navn hentet fra PDL via bulk-oppslag (hentPersonBolk).

## Endringer

- GraphQL-query og datamodeller for `hentPersonBolk`
- `PdlService.getPersonsBolk` for bulk-oppslag mot PDL
- `PersonEnrichmentService` og `PersonEnrichmentTask` som periodisk beriker personer med status PENDING
- Gjentar beriking til alle ventende personer er behandlet
- Tester for PDL-klient og berikingstjeneste

## Relatert

Closes #290

Del av epic #287. Avhenger av #288 og #289.