### PR TITLE
fix(docker-compose): update postgres volume path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: username
       POSTGRES_DB: esyfo-narmesteleder_dev
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
   valkey:
     image: valkey/valkey:latest
     container_name: valkey-server


### PR DESCRIPTION
## Beskrivelse

Oppdaterer databasevolum-pathen i Docker Compose slik at den matcher Postgres 18.

## Endringer

- `docker-compose.yml`: endrer volum-path for Postgres-data fra gammel versjon til Postgres 18-path.

## Issue

Ingen issue koblet.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Merk: Build/test er ikke kjørt for denne PR-opprettelsen.