### PR TITLE
Additional logging related to job cancelation

### DIFF
--- a/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/ConfigureTasks.kt
@@ -49,6 +49,7 @@ fun Application.configureBackgroundTasks() {
             }
 
             is LeaderChange.Demoted -> {
+                logger.info("Demoted from leader — stopping background tasks")
                 taskJobs.lock { jobs ->
                     jobs.cancelAndClear()
                 }
@@ -59,6 +60,7 @@ fun Application.configureBackgroundTasks() {
     }
 
     monitor.subscribe(ApplicationStopPreparing) {
+        logger.info("Received ApplicationStopPreparing — stopping background tasks")
         taskJobs.lock { jobs ->
             jobs.cancelAndClear()
         }


### PR DESCRIPTION
Add more logging around canceling tasks
Specifically when
- Leader is demoted
- subscription of ApplicationStopPreparing triggers