### PR TITLE
fix(leader-election): hindre dobbel SSE-lytter

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Application.kt
+++ b/src/main/kotlin/no/nav/syfo/Application.kt
@@ -39,7 +39,7 @@ fun main() {
 fun Application.module() {
     configureDependencies()
     configureLifecycleHooks(get())
-    configureLeaderMonitoring(get())
+    configureLeaderMonitoring(get(), get())
     configureRouting()
     configureKafkaConsumers()
     configureBackgroundTasks()

--- a/src/main/kotlin/no/nav/syfo/application/leaderelection/LeaderChangeSSEListener.kt
+++ b/src/main/kotlin/no/nav/syfo/application/leaderelection/LeaderChangeSSEListener.kt
@@ -46,6 +46,10 @@ class LeaderChangeSSEListener(
 
     private var hostname: String? = null
 
+    fun initializeLeaderState(isLeader: Boolean) {
+        _isLeader.value = isLeader
+    }
+
     /**
      * Starts listening for leader change events from the NAIS elector sidecar.
      * This is a suspending function that will run indefinitely, collecting SSE events.
@@ -57,44 +61,47 @@ class LeaderChangeSSEListener(
             throw LeaderChangeSSEException("Already listening for leader changes. Only one connection allowed per instance.")
         }
 
-        if (isLocalEnv) {
-            log.info("Running in local environment, setting isLeader to true")
-            _isLeader.value = true
-            return@coroutineScope
-        }
+        try {
+            if (isLocalEnv) {
+                log.info("Running in local environment, setting isLeader to true")
+                initializeLeaderState(isLeader = true)
+                return@coroutineScope
+            }
 
-        hostname = withContext(Dispatchers.IO) { InetAddress.getLocalHost().hostName }
+            hostname = withContext(Dispatchers.IO) { InetAddress.getLocalHost().hostName }
 
-        while (isActive) {
-            runCatching {
-                sseHttpClient.sse(electorSseUrl) {
-                    log.info("Connected to leader election listener for hostname: $hostname")
-                    incoming.collect { event ->
-                        val data = event.data
-                        if (data != null) {
-                            try {
-                                val leaderResponse = jsonMapper.readValue<LeaderElectorResponse>(data)
-                                val isNowLeader = leaderResponse.name == hostname
-                                _isLeader.value = isNowLeader
+            while (isActive) {
+                runCatching {
+                    sseHttpClient.sse(electorSseUrl) {
+                        log.info("Connected to leader election listener for hostname: $hostname")
+                        incoming.collect { event ->
+                            val data = event.data
+                            if (data != null) {
+                                try {
+                                    val leaderResponse = jsonMapper.readValue<LeaderElectorResponse>(data)
+                                    val isNowLeader = leaderResponse.name == hostname
+                                    initializeLeaderState(isNowLeader)
 
-                                log.info(
-                                    "Leader status changed: isLeader=$isNowLeader " +
-                                        "(current leader: ${leaderResponse.name}, this pod: $hostname)"
-                                )
-                            } catch (e: Exception) {
-                                log.warn("Error parsing leader elector response: $data", e)
+                                    log.info(
+                                        "Leader status changed: isLeader=$isNowLeader " +
+                                            "(current leader: ${leaderResponse.name}, this pod: $hostname)"
+                                    )
+                                } catch (e: Exception) {
+                                    log.warn("Error parsing leader elector response: $data", e)
+                                }
                             }
                         }
                     }
-                }
-            }.onFailure {
-                if (it is CancellationException) break
+                }.onFailure {
+                    if (it is CancellationException) break
 
-                log.warn("Could not connect to leader election listener for hostname: $hostname. Retrying in ${SSE_CLIENT_RETRY_DELAY_MS.milliseconds.inWholeSeconds} seconds...", it)
-                delay(SSE_CLIENT_RETRY_DELAY_MS.milliseconds)
+                    log.warn("Could not connect to leader election listener for hostname: $hostname. Retrying in ${SSE_CLIENT_RETRY_DELAY_MS.milliseconds.inWholeSeconds} seconds...", it)
+                    delay(SSE_CLIENT_RETRY_DELAY_MS.milliseconds)
+                }
             }
+        } finally {
+            isListening.set(false)
         }
-        isListening.set(false)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/DependencyInjection.kt
@@ -28,6 +28,7 @@ import no.nav.syfo.application.environment.isLocalEnv
 import no.nav.syfo.application.kafka.JacksonKafkaSerializer
 import no.nav.syfo.application.kafka.producerProperties
 import no.nav.syfo.application.leaderelection.LeaderChangeSSEListener
+import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.application.valkey.EregCache
 import no.nav.syfo.application.valkey.PdlCache
 import no.nav.syfo.application.valkey.ValkeyCache
@@ -263,6 +264,9 @@ private fun servicesModule() = module {
     single { AltinnTilgangerService(get()) }
     single {
         LeaderChangeSSEListener(httpClientSSE(), env().otherProperties.electorSSEUrl, isLocalEnv())
+    }
+    single {
+        LeaderElection(get(), env().otherProperties.electorPath)
     }
     single {
         val sykmeldingNLKafkaProducer = SykmeldingNLKafkaProducer(

--- a/src/main/kotlin/no/nav/syfo/plugins/LeaderMonitoringPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/LeaderMonitoringPlugin.kt
@@ -3,33 +3,51 @@ package no.nav.syfo.plugins
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopPreparing
 import io.ktor.server.application.ServerReady
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.launch
 import no.nav.syfo.application.events.LeaderChange
 import no.nav.syfo.application.events.LeaderChangeEvent
 import no.nav.syfo.application.leaderelection.LeaderChangeSSEListener
+import no.nav.syfo.application.leaderelection.LeaderElection
 import no.nav.syfo.util.logger
 
-fun Application.configureLeaderMonitoring(leaderChangeSSEListener: LeaderChangeSSEListener) {
+fun Application.configureLeaderMonitoring(
+    leaderChangeSSEListener: LeaderChangeSSEListener,
+    leaderElection: LeaderElection,
+) {
     val log = logger()
 
     monitor.subscribe(ServerReady) {
         log.info("Starting leader monitoring")
         val job = launch {
+            var wasLeader = false
+            launch(start = CoroutineStart.UNDISPATCHED) {
+                leaderChangeSSEListener.isLeader.collectIndexed { index, isLeader ->
+                    val event = deriveLeaderChangeEvent(index, wasLeader, isLeader)
+                    wasLeader = isLeader
+
+                    if (event == null) return@collectIndexed
+
+                    log.info("Leader change event: {}", event::class.simpleName)
+                    monitor.raise(LeaderChangeEvent, event)
+                }
+            }
+
+            runCatching {
+                leaderElection.isLeader()
+            }.onSuccess { initialIsLeader ->
+                leaderChangeSSEListener.initializeLeaderState(initialIsLeader)
+                log.info("Initialized leader state from simple API: isLeader={}", initialIsLeader)
+            }.onFailure { exception ->
+                log.error(
+                    "Failed to initialize leader state from simple API; continuing leader monitoring with SSE listener",
+                    exception
+                )
+            }
+
             log.info("Before listenForLeaderChanges - Application.configureLeaderMonitoring")
             launch { leaderChangeSSEListener.listenForLeaderChanges() }
-
-            var wasLeader = false
-            leaderChangeSSEListener.isLeader.collectIndexed { index, isLeader ->
-                val event = deriveLeaderChange(wasLeader, isLeader)
-                wasLeader = isLeader
-
-                // Skip the initial default value (false) from MutableStateFlow
-                if (index == 0 && event is LeaderChange.Unaffected) return@collectIndexed
-
-                log.info("Leader change event: {}", event::class.simpleName)
-                monitor.raise(LeaderChangeEvent, event)
-            }
         }
 
         monitor.subscribe(ApplicationStopPreparing) {
@@ -42,4 +60,14 @@ internal fun deriveLeaderChange(wasLeader: Boolean, isLeader: Boolean): LeaderCh
     !wasLeader && isLeader -> LeaderChange.Promoted
     wasLeader && !isLeader -> LeaderChange.Demoted
     else -> LeaderChange.Unaffected
+}
+
+internal fun deriveLeaderChangeEvent(index: Int, wasLeader: Boolean, isLeader: Boolean): LeaderChange? {
+    val event = deriveLeaderChange(wasLeader, isLeader)
+
+    return if (index == 0 && event is LeaderChange.Unaffected) {
+        null
+    } else {
+        event
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/plugins/LeaderMonitoringPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/LeaderMonitoringPlugin.kt
@@ -16,6 +16,7 @@ fun Application.configureLeaderMonitoring(leaderChangeSSEListener: LeaderChangeS
     monitor.subscribe(ServerReady) {
         log.info("Starting leader monitoring")
         val job = launch {
+            log.info("Before listenForLeaderChanges - Application.configureLeaderMonitoring")
             launch { leaderChangeSSEListener.listenForLeaderChanges() }
 
             var wasLeader = false

--- a/src/main/kotlin/no/nav/syfo/plugins/RunningTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/RunningTasks.kt
@@ -112,8 +112,6 @@ fun Application.configureKafkaConsumers() {
     )
 
     monitor.subscribe(ServerReady) {
-        logger.info("Before listenForLeaderChanges - RunningTasks - Kafka consumers")
-        val sseListenerJob = launch { leaderChangeSSEListener.listenForLeaderChanges() }
         val leaderControlledConsumersJob = launch(Dispatchers.IO) {
             leaderChangeSSEListener.isLeader.collect { isLeader ->
                 leaderControlledConsumers.forEach { consumer ->
@@ -123,11 +121,9 @@ fun Application.configureKafkaConsumers() {
         }
         leesahConsumer.listen()
         sendtSykmeldingConsumer.listen()
-
         monitor.subscribe(ApplicationStopPreparing) {
             runBlocking {
                 leaderControlledConsumersJob.cancelAndJoin()
-                sseListenerJob.cancelAndJoin()
                 leaderControlledConsumers.forEach { consumer ->
                     consumer.stop()
                     consumer.close()

--- a/src/main/kotlin/no/nav/syfo/plugins/RunningTasks.kt
+++ b/src/main/kotlin/no/nav/syfo/plugins/RunningTasks.kt
@@ -112,6 +112,7 @@ fun Application.configureKafkaConsumers() {
     )
 
     monitor.subscribe(ServerReady) {
+        logger.info("Before listenForLeaderChanges - RunningTasks - Kafka consumers")
         val sseListenerJob = launch { leaderChangeSSEListener.listenForLeaderChanges() }
         val leaderControlledConsumersJob = launch(Dispatchers.IO) {
             leaderChangeSSEListener.isLeader.collect { isLeader ->

--- a/src/test/kotlin/no/nav/syfo/application/leaderelection/LeaderChangeSSEListenerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/leaderelection/LeaderChangeSSEListenerTest.kt
@@ -45,5 +45,18 @@ class LeaderChangeSSEListenerTest :
 
                 listener.isLeader.value shouldBe false
             }
+
+            it("should initialize leader state from simple API result") {
+                val mockEngine =
+                    MockEngine { _ ->
+                        respond("", HttpStatusCode.InternalServerError)
+                    }
+                val httpClient = HttpClient(mockEngine)
+                val listener = LeaderChangeSSEListener(httpClient, "http://localhost/elector", false)
+
+                listener.initializeLeaderState(isLeader = true)
+
+                listener.isLeader.value shouldBe true
+            }
         }
     })

--- a/src/test/kotlin/no/nav/syfo/plugins/LeaderMonitoringPluginTest.kt
+++ b/src/test/kotlin/no/nav/syfo/plugins/LeaderMonitoringPluginTest.kt
@@ -42,4 +42,18 @@ class LeaderMonitoringPluginTest :
                 results shouldBe listOf("promoted", "demoted", "unaffected")
             }
         }
+
+        describe("deriveLeaderChangeEvent") {
+            it("should skip the initial default non-leader emission") {
+                deriveLeaderChangeEvent(index = 0, wasLeader = false, isLeader = false) shouldBe null
+            }
+
+            it("should emit promoted after the initial default non-leader emission") {
+                deriveLeaderChangeEvent(index = 1, wasLeader = false, isLeader = true) shouldBe LeaderChange.Promoted
+            }
+
+            it("should emit promoted when the pod is already leader on initial state") {
+                deriveLeaderChangeEvent(index = 0, wasLeader = false, isLeader = true) shouldBe LeaderChange.Promoted
+            }
+        }
     })


### PR DESCRIPTION
## Beskrivelse

Hindrer at `LeaderChangeSSEListener` startes dobbelt ved oppstart. Leader-monitoring eier nå SSE-lyttingen alene, initialiserer leader-state fra elector simple API før SSE-listeneren starter, og sender dermed riktig leader-change event også når podden allerede er leader ved oppstart.

## Endringer

- `Application.kt` og dependency injection: kobler `LeaderElection` inn i leader-monitoring.
- `LeaderMonitoringPlugin`: initialiserer leader-state før SSE, starter SSE-listener ett sted, og filtrerer bare bort første default non-leader-emission.
- `RunningTasks`: fjerner egen oppstart og shutdown av `LeaderChangeSSEListener` for å unngå dobbel kjøring.
- Tester: dekker initialisering av leader-state og event-derivasjon for første emission.

## Issue

Ingen issue koblet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`./gradlew --no-daemon clean build`)
- [x] Endringene er testet automatisk (`./gradlew --no-daemon clean build`)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
