### PR TITLE
feat(api): validate manager contact payloads

### DIFF
--- a/.bruno/environments/nl_vars_dev.bru
+++ b/.bruno/environments/nl_vars_dev.bru
@@ -3,7 +3,7 @@ vars {
   baseUrlIntern: https://narmesteleder-api.intern.dev.nav.no
   currentId: {{process.env.BEHOV_ID}}
   identityProvider: 
-  systemKundeOrgnr: 314218256
+  systemKundeOrgnr: 314252217
   systemEierOrgnr: 215649202
 }
 vars:secret [

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.narmesteleder.api.v1
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -39,7 +40,7 @@ fun Route.registerLinemanagerApiV1(
             val principal = call.getMyPrincipal()
             val create = validationService.normalizeLinemanagerPayload(
                 linemanager = call.tryReceive<Linemanager>(),
-                context = "path=${call.request.path()}, callId=${call.callId ?: "missing"}, principalType=${principal::class.simpleName}",
+                context = "operation=${call.request.httpMethod} ${call.request.path()}, callId=${call.callId ?: "missing"}, principalType=${principal::class.simpleName}",
             )
             val actors = validationService.validateLinemanager(create, principal)
 
@@ -80,11 +81,14 @@ fun Route.registerLinemanagerApiV1(
             val principal = call.getMyPrincipal()
             val id = call.getUUIDFromPathVariable(name = "id")
             val linemanager = call.tryReceive<Manager>()
+            val context =
+                "operation=${call.request.httpMethod} ${call.request.path()}, callId=${call.callId ?: "missing"}, principalType=${principal::class.simpleName}"
 
             linemanagerRequirementRestHandler.handleUpdatedRequirement(
                 linemanager,
                 requirementId = id,
-                principal = principal
+                principal = principal,
+                context = context,
             )
             when (principal) {
                 is SystemPrincipal -> COUNT_FULFILL_LINEMANAGER_REQUIREMENT_BY_LPS.increment()

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.narmesteleder.api.v1
 
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.request.path
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
@@ -35,8 +37,11 @@ fun Route.registerLinemanagerApiV1(
 
         post {
             val principal = call.getMyPrincipal()
-            val create = call.tryReceive<Linemanager>()
-            val actors = validationService.validateLinemanager(create, call.getMyPrincipal())
+            val create = validationService.normalizeLinemanagerPayload(
+                linemanager = call.tryReceive<Linemanager>(),
+                context = "path=${call.request.path()}, callId=${call.callId ?: "missing"}, principalType=${principal::class.simpleName}",
+            )
+            val actors = validationService.validateLinemanager(create, principal)
 
             narmestelederKafkaService.sendNarmesteLederRelasjon(
                 create,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
@@ -29,12 +29,13 @@ class LinemanagerRequirementRESTHandler(
     suspend fun handleUpdatedRequirement(
         manager: Manager,
         requirementId: UUID,
-        principal: Principal
+        principal: Principal,
+        context: String,
     ) {
         try {
             val normalizedManager = validationService.normalizeManagerPayload(
                 manager = manager,
-                context = "operation=PUT /linemanager/requirement/{id}, requirementId=$requirementId, principalType=${principal::class.simpleName}",
+                context = context,
             )
             val employee = narmesteLederService.getEmployeeByRequirementId(requirementId)
             val linemanager = Linemanager(

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
@@ -32,12 +32,16 @@ class LinemanagerRequirementRESTHandler(
         principal: Principal
     ) {
         try {
+            val normalizedManager = validationService.normalizeManagerPayload(
+                manager = manager,
+                context = "operation=PUT /linemanager/requirement/{id}, requirementId=$requirementId, principalType=${principal::class.simpleName}",
+            )
             val employee = narmesteLederService.getEmployeeByRequirementId(requirementId)
             val linemanager = Linemanager(
                 employeeIdentificationNumber = employee.nationalIdentificationNumber,
                 orgNumber = employee.orgNumber,
                 lastName = employee.lastName,
-                manager = manager
+                manager = normalizedManager
             )
             val linemanagerActors = validationService.validateLinemanager(
                 linemanager = linemanager,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/EmailAddress.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/EmailAddress.kt
@@ -1,0 +1,39 @@
+package no.nav.syfo.narmesteleder.domain
+
+private val EMAIL_ADDRESS_REGEX = Regex(
+    pattern =
+    "^[A-Za-z0-9ÆØÅæøå._%+-]+@[A-Za-z0-9ÆØÅæøå](?:[A-Za-z0-9ÆØÅæøå-]{0,61}[A-Za-z0-9ÆØÅæøå])?(?:\\.[A-Za-z0-9ÆØÅæøå](?:[A-Za-z0-9ÆØÅæøå-]{0,61}[A-Za-z0-9ÆØÅæøå])?)+\$"
+)
+
+@JvmInline
+value class EmailAddress(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "EmailAddress must not be blank"
+        }
+        value
+            .split(";")
+            .forEach { emailPart ->
+                require(emailPart.isNotBlank()) {
+                    "EmailAddress must not contain empty email entries"
+                }
+                require(emailPart.none(Char::isWhitespace)) {
+                    "EmailAddress must not contain whitespace"
+                }
+                require(EMAIL_ADDRESS_REGEX.matches(emailPart)) {
+                    "EmailAddress must be a valid email address"
+                }
+            }
+    }
+
+    companion object {
+        fun parse(value: String): Result<EmailAddress> = runCatching {
+            EmailAddress(
+                value = value
+                    .split(";")
+                    .map(String::trim)
+                    .joinToString(";"),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/EmailAddress.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/EmailAddress.kt
@@ -1,5 +1,11 @@
 package no.nav.syfo.narmesteleder.domain
 
+/*
+ * Matches one email address after semicolon-separated input has been split and trimmed.
+ * The local-part allows letters, digits, common email symbols, plus signs and Norwegian letters.
+ * Each domain label must start and end with a letter or digit, may contain hyphens in the middle,
+ * and the address must contain at least one dot in the domain.
+ */
 private val EMAIL_ADDRESS_REGEX = Regex(
     pattern =
     "^[A-Za-z0-9ÆØÅæøå._%+-]+@[A-Za-z0-9ÆØÅæøå](?:[A-Za-z0-9ÆØÅæøå-]{0,61}[A-Za-z0-9ÆØÅæøå])?(?:\\.[A-Za-z0-9ÆØÅæøå](?:[A-Za-z0-9ÆØÅæøå-]{0,61}[A-Za-z0-9ÆØÅæøå])?)+\$"

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/ManagerContactDetails.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/ManagerContactDetails.kt
@@ -1,0 +1,49 @@
+package no.nav.syfo.narmesteleder.domain
+
+data class ContactValidationIssue(
+    val fieldName: String,
+    val reason: String,
+)
+
+data class ManagerContactDetailsValidation(
+    val manager: Manager,
+    val issues: List<ContactValidationIssue>,
+)
+
+fun Manager.normalizeContactDetails(): ManagerContactDetailsValidation {
+    val issues = mutableListOf<ContactValidationIssue>()
+
+    val normalizedMobile = PhoneNumber.parse(mobile)
+        .onFailure {
+            issues.add(
+                ContactValidationIssue(
+                    fieldName = "mobile",
+                    reason = it.message ?: "Invalid phone number",
+                )
+            )
+        }
+        .getOrNull()
+        ?.value
+        ?: mobile
+
+    val normalizedEmail = EmailAddress.parse(email)
+        .onFailure {
+            issues.add(
+                ContactValidationIssue(
+                    fieldName = "email",
+                    reason = it.message ?: "Invalid email address",
+                )
+            )
+        }
+        .getOrNull()
+        ?.value
+        ?: email
+
+    return ManagerContactDetailsValidation(
+        manager = copy(
+            mobile = normalizedMobile,
+            email = normalizedEmail,
+        ),
+        issues = issues,
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/PhoneNumber.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/PhoneNumber.kt
@@ -1,0 +1,23 @@
+package no.nav.syfo.narmesteleder.domain
+
+private val PHONE_NUMBER_REGEX = Regex("^\\+?\\d+$")
+
+@JvmInline
+value class PhoneNumber(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "PhoneNumber must not be blank"
+        }
+        require(PHONE_NUMBER_REGEX.matches(value)) {
+            "PhoneNumber must contain only digits, with an optional leading plus sign"
+        }
+    }
+
+    companion object {
+        fun parse(value: String): Result<PhoneNumber> = runCatching {
+            PhoneNumber(
+                value = value.replace(" ", ""),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
@@ -2,16 +2,20 @@ package no.nav.syfo.narmesteleder.service
 
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.application.auth.Principal
+import no.nav.syfo.narmesteleder.domain.ContactValidationIssue
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerActors
 import no.nav.syfo.narmesteleder.domain.LinemanagerRevoke
+import no.nav.syfo.narmesteleder.domain.Manager
 import no.nav.syfo.narmesteleder.domain.OrganizationNumber
+import no.nav.syfo.narmesteleder.domain.normalizeContactDetails
 import no.nav.syfo.narmesteleder.service.validators.ArbeidsforholdValidator
 import no.nav.syfo.narmesteleder.service.validators.NameValidator
 import no.nav.syfo.narmesteleder.service.validators.PrincipalAccessValidator
 import no.nav.syfo.narmesteleder.service.validators.SickLeaveValidator
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.pdl.Person
+import no.nav.syfo.util.logger
 
 class ValidationService(
     private val pdlService: PdlService,
@@ -19,6 +23,27 @@ class ValidationService(
     private val principalAccessValidator: PrincipalAccessValidator,
     private val sickLeaveValidator: SickLeaveValidator,
 ) {
+    private val logger = logger()
+
+    fun normalizeLinemanagerPayload(
+        linemanager: Linemanager,
+        context: String,
+    ): Linemanager = linemanager.copy(
+        manager = normalizeManagerPayload(
+            manager = linemanager.manager,
+            context = context,
+        )
+    )
+
+    fun normalizeManagerPayload(
+        manager: Manager,
+        context: String,
+    ): Manager {
+        val validation = manager.normalizeContactDetails()
+        logContactValidationIssues(validation.issues, context)
+        return validation.manager
+    }
+
     suspend fun validateLinemanager(
         linemanager: Linemanager,
         principal: Principal,
@@ -74,4 +99,18 @@ class ValidationService(
         principal: Principal,
         orgNumber: OrganizationNumber,
     ): String? = principalAccessValidator.validatePrincipalAccessToOrgnumber(principal, orgNumber.value)
+
+    private fun logContactValidationIssues(
+        issues: List<ContactValidationIssue>,
+        context: String,
+    ) {
+        issues.forEach { issue ->
+            logger.warn(
+                "ContactValidationIssue: Received manager payload with invalid {} for {}. Keeping original value. Reason: {}",
+                issue.fieldName,
+                context,
+                issue.reason,
+            )
+        }
+    }
 }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -500,12 +500,11 @@ components:
           example: "Jensen"
         mobile:
           type: string
-          description: Mobile phone number of the manager.
+          description: Mobile phone number of the manager. Spaces are accepted and removed before further use. A plus sign is only allowed as the first character.
           example: "+4790000000"
         email:
           type: string
-          format: email
-          description: Email address of the manager.
+          description: One or more email addresses for the manager. Addresses may be separated with semicolon. A plus sign and the Norwegian letters æ, ø and å are allowed in both the local-part and domain-part.
           example: "leder@example.com"
       required:
         - nationalIdentificationNumber

--- a/src/test/kotlin/TestUtil.kt
+++ b/src/test/kotlin/TestUtil.kt
@@ -48,8 +48,8 @@ val faker = Faker(Random(Instant.now().epochSecond))
 fun faker() = faker
 fun manager(): Manager = Manager(
     nationalIdentificationNumber = PersonalIdentificationNumber(faker.numerify("###########")),
-    mobile = faker.phoneNumber().cellPhone(),
-    email = faker.internet().emailAddress(),
+    mobile = "+47${faker.numerify("########")}",
+    email = "test+${faker.numerify("#####")}@example.com",
     lastName = faker.name().lastName(),
 )
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandlerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandlerTest.kt
@@ -68,11 +68,14 @@ class LinemanagerRequirementRESTHandlerTest :
                     systemOwner = "0192:systemOwner",
                     systemUserId = "systemUserId",
                 )
+                val context =
+                    "operation=put thepath, principalType=${principal::class.simpleName}"
 
                 handler.handleUpdatedRequirement(
                     requirementId = fixtureEntity.id!!,
                     manager = defaultManager,
                     principal = principal,
+                    context = context,
                 )
                 coVerify(exactly = 1) {
                     servicesWrapper.narmestelederServiceSpyk.updateNlBehov(
@@ -96,11 +99,14 @@ class LinemanagerRequirementRESTHandlerTest :
                     systemOwner = "0192:systemOwner",
                     systemUserId = "systemUserId",
                 )
+                val context =
+                    "operation=put thepath, principalType=${principal::class.simpleName}"
 
                 handler.handleUpdatedRequirement(
                     requirementId = fixtureEntity.id!!,
                     manager = defaultManager,
                     principal = principal,
+                    context = context,
                 )
                 coVerify(exactly = 1) {
                     servicesWrapper.narmestelederKafkaServiceSpyk.sendNarmesteLederRelasjon(

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
@@ -217,6 +217,98 @@ class LinenmanagerApiV1Test :
                     }
                 }
 
+                it("Maskinporten POST /linemanager should normalize spaces in valid phone numbers") {
+                    withTestApplication {
+                        val linemanagerWithSpacedPhone = narmesteLederRelasjon.copy(
+                            manager = narmesteLederRelasjon.manager.copy(
+                                mobile = "+47 90 00 00 00",
+                                email = "leder+ø@eksempelø.no; annen@domene.no ",
+                            ),
+                        )
+                        pdlService.prepareGetPersonResponse(linemanagerWithSpacedPhone.manager)
+                        pdlService.prepareGetPersonResponse(
+                            linemanagerWithSpacedPhone.employeeIdentificationNumber.value,
+                            linemanagerWithSpacedPhone.lastName,
+                        )
+                        texasHttpClientMock.defaultMocks(
+                            systemBrukerOrganisasjon =
+                            DefaultOrganization.copy(
+                                ID = "0192:${linemanagerWithSpacedPhone.orgNumber.value}",
+                            ),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+                        fakeAaregClient.arbeidsForholdForIdent[linemanagerWithSpacedPhone.employeeIdentificationNumber.value] =
+                            listOf(linemanagerWithSpacedPhone.orgNumber.value to linemanagerWithSpacedPhone.orgNumber.value)
+                        fakeAaregClient.arbeidsForholdForIdent[linemanagerWithSpacedPhone.manager.nationalIdentificationNumber.value] =
+                            listOf(linemanagerWithSpacedPhone.orgNumber.value to linemanagerWithSpacedPhone.orgNumber.value)
+
+                        val response =
+                            client.post("/api/v1/linemanager") {
+                                contentType(ContentType.Application.Json)
+                                setBody(linemanagerWithSpacedPhone)
+                                bearerAuth(createMockToken(linemanagerWithSpacedPhone.orgNumber.value))
+                            }
+
+                        response.status shouldBe HttpStatusCode.Accepted
+                        coVerify(exactly = 1) {
+                            narmestelederKafkaServiceSpy.sendNarmesteLederRelasjon(
+                                match {
+                                    it.manager.mobile == "+4790000000" &&
+                                        it.manager.email == "leder+ø@eksempelø.no;annen@domene.no"
+                                },
+                                any(),
+                                NlResponseSource.LPS,
+                            )
+                        }
+                    }
+                }
+
+                it("Maskinporten POST /linemanager should accept invalid phone and email without rejecting payload") {
+                    withTestApplication {
+                        val linemanagerWithInvalidContacts = narmesteLederRelasjon.copy(
+                            manager = narmesteLederRelasjon.manager.copy(
+                                mobile = "90-00-00-00",
+                                email = "gyldig@example.com; invalid @example.com",
+                            ),
+                        )
+                        pdlService.prepareGetPersonResponse(linemanagerWithInvalidContacts.manager)
+                        pdlService.prepareGetPersonResponse(
+                            linemanagerWithInvalidContacts.employeeIdentificationNumber.value,
+                            linemanagerWithInvalidContacts.lastName,
+                        )
+                        texasHttpClientMock.defaultMocks(
+                            systemBrukerOrganisasjon =
+                            DefaultOrganization.copy(
+                                ID = "0192:${linemanagerWithInvalidContacts.orgNumber.value}",
+                            ),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+                        fakeAaregClient.arbeidsForholdForIdent[linemanagerWithInvalidContacts.employeeIdentificationNumber.value] =
+                            listOf(linemanagerWithInvalidContacts.orgNumber.value to linemanagerWithInvalidContacts.orgNumber.value)
+                        fakeAaregClient.arbeidsForholdForIdent[linemanagerWithInvalidContacts.manager.nationalIdentificationNumber.value] =
+                            listOf(linemanagerWithInvalidContacts.orgNumber.value to linemanagerWithInvalidContacts.orgNumber.value)
+
+                        val response =
+                            client.post("/api/v1/linemanager") {
+                                contentType(ContentType.Application.Json)
+                                setBody(linemanagerWithInvalidContacts)
+                                bearerAuth(createMockToken(linemanagerWithInvalidContacts.orgNumber.value))
+                            }
+
+                        response.status shouldBe HttpStatusCode.Accepted
+                        coVerify(exactly = 1) {
+                            narmestelederKafkaServiceSpy.sendNarmesteLederRelasjon(
+                                match {
+                                    it.manager.mobile == "90-00-00-00" &&
+                                        it.manager.email == "gyldig@example.com; invalid @example.com"
+                                },
+                                any(),
+                                NlResponseSource.LPS,
+                            )
+                        }
+                    }
+                }
+
                 it("should return 400 Bad Request for invalid payload") {
                     withTestApplication {
                         // Arrange
@@ -707,6 +799,45 @@ class LinenmanagerApiV1Test :
                         }
                         val stored = fakeRepo.findBehovById(requirementId) ?: error("Stored requirement missing")
                         stored.behovStatus.name shouldBe BehovStatus.BEHOV_FULFILLED.name
+                    }
+                }
+
+                it("PUT /requirement/{id} should normalize spaces in valid phone numbers") {
+                    withTestApplication {
+                        texasHttpClientMock.defaultMocks(
+                            systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:$orgnummer"),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+                        val requirementId = seedLinemanagerRequirement()
+                        val spacedPhoneManager = manager().copy(
+                            nationalIdentificationNumber = PersonalIdentificationNumber(
+                                narmesteLederRelasjon.manager.nationalIdentificationNumber.value.reversed(),
+                            ),
+                            mobile = "+47 90 00 00 00",
+                            email = "leder+ø@eksempelø.no; annen@domene.no ",
+                        )
+                        pdlService.prepareGetPersonResponse(spacedPhoneManager)
+                        fakeAaregClient.arbeidsForholdForIdent[spacedPhoneManager.nationalIdentificationNumber.value] =
+                            listOf(orgnummer to orgnummer)
+
+                        val response =
+                            client.put("$API_V1_PATH/$RECUIREMENT_PATH/$requirementId") {
+                                contentType(ContentType.Application.Json)
+                                setBody(spacedPhoneManager)
+                                bearerAuth(createMockToken(orgnummer))
+                            }
+
+                        response.status shouldBe HttpStatusCode.Accepted
+                        coVerify(exactly = 1) {
+                            narmestelederKafkaServiceSpy.sendNarmesteLederRelasjon(
+                                match { linemanager ->
+                                    linemanager.manager.mobile == "+4790000000" &&
+                                        linemanager.manager.email == "leder+ø@eksempelø.no;annen@domene.no"
+                                },
+                                any(),
+                                any(),
+                            )
+                        }
                     }
                 }
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
@@ -1,10 +1,15 @@
 package no.nav.syfo.narmesteleder.service
 
 import DefaultSystemPrincipal
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import faker
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -13,6 +18,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import linemanager
 import linemanagerRevoke
+import manager
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.aareg.client.FakeAaregClient
 import no.nav.syfo.altinn.pdp.client.FakePdpClient
@@ -32,12 +38,14 @@ import no.nav.syfo.ereg.EregService
 import no.nav.syfo.ereg.client.FakeEregClient
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerRevoke
+import no.nav.syfo.narmesteleder.domain.Manager
 import no.nav.syfo.narmesteleder.domain.OrganizationNumber
 import no.nav.syfo.narmesteleder.domain.PersonalIdentificationNumber
 import no.nav.syfo.narmesteleder.service.validators.PrincipalAccessValidator
 import no.nav.syfo.narmesteleder.service.validators.SickLeaveValidator
 import no.nav.syfo.pdl.PdlService
 import no.nav.syfo.pdl.client.FakePdlClient
+import org.slf4j.LoggerFactory
 import prepareGetPersonResponse
 
 class ValidationServiceTest :
@@ -71,6 +79,9 @@ class ValidationServiceTest :
             principalAccessValidator = principalAccessValidator,
             sickLeaveValidator = sickLeaveValidator,
         )
+        val logbackLogger = LoggerFactory.getLogger(ValidationService::class.java) as Logger
+        val logAppender = ListAppender<ILoggingEvent>()
+        val originalLevel = logbackLogger.level
 
         fun differentLastName(lastName: String): String = faker.name().lastName().let {
             if (it != lastName) it else lastName.reversed()
@@ -117,6 +128,20 @@ class ValidationServiceTest :
             )
         }
 
+        fun warningMessages(): List<String> = logAppender.list.map { it.formattedMessage }
+
+        beforeSpec {
+            logbackLogger.level = Level.WARN
+            logAppender.start()
+            logbackLogger.addAppender(logAppender)
+        }
+
+        afterSpec {
+            logbackLogger.detachAppender(logAppender)
+            logAppender.stop()
+            logbackLogger.level = originalLevel
+        }
+
         beforeTest {
             clearAllMocks()
             altinnTilgangerClient.reset()
@@ -124,6 +149,65 @@ class ValidationServiceTest :
             coEvery { eregCache.getOrganisasjon(any()) } returns null
             aaregClient.arbeidsForholdForIdent.clear()
             eregClient.organisasjoner.clear()
+            logAppender.list.clear()
+        }
+        describe("normalize manager contact details") {
+            it("should normalize valid manager payload without warnings") {
+                val linemanager = linemanager().copy(
+                    manager = manager().copy(
+                        mobile = "+47 90 00 00 00",
+                        email = "leder+ø@eksempelø.no; annen@domene.no ",
+                    )
+                )
+
+                val normalized = service.normalizeLinemanagerPayload(
+                    linemanager = linemanager,
+                    context = "path=/api/v1/linemanager",
+                )
+
+                normalized.manager.mobile shouldBe "+4790000000"
+                normalized.manager.email shouldBe "leder+ø@eksempelø.no;annen@domene.no"
+                warningMessages() shouldHaveSize 0
+            }
+
+            it("should keep invalid manager contact details and log warnings without raw values") {
+                val manager = Manager(
+                    nationalIdentificationNumber = PersonalIdentificationNumber("12345678910"),
+                    lastName = "Jensen",
+                    mobile = "90-00-00-00",
+                    email = "gyldig@example.com; invalid @example.com",
+                )
+
+                val normalized = service.normalizeManagerPayload(
+                    manager = manager,
+                    context = "operation=PUT /linemanager/requirement/{id}",
+                )
+
+                normalized shouldBe manager
+                warningMessages() shouldHaveSize 2
+                warningMessages().single { it.contains("invalid mobile") } shouldBe
+                    "ContactValidationIssue: Received manager payload with invalid mobile for operation=PUT /linemanager/requirement/{id}. Keeping original value. Reason: PhoneNumber must contain only digits, with an optional leading plus sign"
+                warningMessages().single { it.contains("invalid email") } shouldBe
+                    "ContactValidationIssue: Received manager payload with invalid email for operation=PUT /linemanager/requirement/{id}. Keeping original value. Reason: EmailAddress must not contain whitespace"
+                warningMessages().any { it.contains("90-00-00-00") } shouldBe false
+                warningMessages().any { it.contains("invalid @example.com") } shouldBe false
+                warningMessages().any { it.contains("gyldig@example.com") } shouldBe false
+            }
+
+            it("should keep phone numbers with misplaced plus sign and log warning") {
+                val manager = manager().copy(
+                    mobile = "47+90000000",
+                )
+
+                val normalized = service.normalizeManagerPayload(
+                    manager = manager,
+                    context = "path=/api/v1/linemanager",
+                )
+
+                normalized.mobile shouldBe "47+90000000"
+                warningMessages().single() shouldBe
+                    "ContactValidationIssue: Received manager payload with invalid mobile for path=/api/v1/linemanager. Keeping original value. Reason: PhoneNumber must contain only digits, with an optional leading plus sign"
+            }
         }
         describe("validateNarmesteleder") {
             it("should not thrown when all validation passes and principal is BrukerPrincipal") {


### PR DESCRIPTION
## Beskrivelse

Legger til passiv validering og normalisering av manager-kontaktinfo for API-payloads i linemanager-flyten. Telefonnumre normaliseres ved å fjerne mellomrom, e-postfeltet støtter flere adresser separert med `;`, og ugyldige verdier logges uten å avvise requesten.

Kafka-innlesing av telefonnummer og e-post er bevisst uendret.

## Endringer

- `src/main/kotlin/no/nav/syfo/narmesteleder/domain/*` - la til value classes og normalisering for telefonnummer og e-post
- `src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/*` - normaliserer manager-payload i POST/PUT-flytene før videre behandling
- `src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt` - passiv validering og logging uten å endre responsflyt
- `src/main/resources/openapi/documentation.yaml` - dokumenterer nye regler for telefon og e-post
- `src/test/kotlin/no/nav/syfo/narmesteleder/**/*` - tester for mellomrom i telefon, `+` kun først, `æøå` i e-post og semikolon-separerte adresser

## Issue

Closes #402

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
