### PR TITLE
Feature total meta requirements

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerApi.kt
@@ -13,7 +13,6 @@ import io.ktor.server.routing.route
 import no.nav.syfo.application.auth.SystemPrincipal
 import no.nav.syfo.application.auth.UserPrincipal
 import no.nav.syfo.narmesteleder.domain.Linemanager
-import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementCollection
 import no.nav.syfo.narmesteleder.domain.LinemanagerRevoke
 import no.nav.syfo.narmesteleder.domain.Manager
 import no.nav.syfo.narmesteleder.kafka.model.NlResponseSource
@@ -117,10 +116,7 @@ fun Route.registerLinemanagerApiV1(
                 orgNumber = orgNumber,
                 principal = principal,
             )
-            call.respond(
-                HttpStatusCode.OK,
-                LinemanagerRequirementCollection.from(collection, pageSize)
-            )
+            call.respond(HttpStatusCode.OK, collection)
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.application.auth.Principal
 import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.narmesteleder.domain.BehovStatus
 import no.nav.syfo.narmesteleder.domain.Linemanager
+import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementCollection
 import no.nav.syfo.narmesteleder.domain.LinemanagerRequirementRead
 import no.nav.syfo.narmesteleder.domain.Manager
 import no.nav.syfo.narmesteleder.domain.OrganizationNumber
@@ -91,13 +92,22 @@ class LinemanagerRequirementRESTHandler(
         createdAfter: Instant,
         orgNumber: OrganizationNumber,
         principal: Principal
-    ): List<LinemanagerRequirementRead> {
+    ): LinemanagerRequirementCollection {
         val orgName = validationService.validatePrincipalAccessToOrgnumber(principal, orgNumber)
         logger.info("Validation successful for fetching LinemanagerRequirement collection for orgNumber: ${orgNumber.value}")
-        return narmesteLederService.getNlBehovList(
+        val requirements = narmesteLederService.getNlBehovList(
             pageSize = pageSize,
             createdAfter = createdAfter,
             orgNumber = orgNumber
         ).map { it.copy(orgName = orgName) }
+        val total = narmesteLederService.countNlBehov(
+            orgNumber = orgNumber,
+            createdAfter = createdAfter,
+        )
+        return LinemanagerRequirementCollection.from(
+            list = requirements,
+            pageSize = pageSize,
+            total = total,
+        )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/api/v1/LinemanagerRequirementRESTHandler.kt
@@ -100,10 +100,14 @@ class LinemanagerRequirementRESTHandler(
             createdAfter = createdAfter,
             orgNumber = orgNumber
         ).map { it.copy(orgName = orgName) }
-        val total = narmesteLederService.countNlBehov(
-            orgNumber = orgNumber,
-            createdAfter = createdAfter,
-        )
+        val total = if (requirements.size > pageSize) {
+            narmesteLederService.countNlBehov(
+                orgNumber = orgNumber,
+                createdAfter = createdAfter,
+            )
+        } else {
+            null
+        }
         return LinemanagerRequirementCollection.from(
             list = requirements,
             pageSize = pageSize,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/db/NarmestelederDb.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/db/NarmestelederDb.kt
@@ -28,6 +28,12 @@ interface INarmestelederDb {
         limit: Int
     ): List<NarmestelederBehovEntity>
 
+    suspend fun countBehovByParameters(
+        orgNumber: String,
+        createdAfter: Instant,
+        status: List<BehovStatus>,
+    ): Long
+
     suspend fun setBehovStatusForSykmeldingWithTomBeforeAndStatus(
         tomBefore: Instant,
         newStatus: BehovStatus,
@@ -256,6 +262,40 @@ class NarmestelederDb(
                         nlBehov.add(resultSet.toNarmestelederBehovEntity())
                     }
                     nlBehov
+                }
+        }
+    }
+
+    override suspend fun countBehovByParameters(
+        orgNumber: String,
+        createdAfter: Instant,
+        status: List<BehovStatus>,
+    ): Long = withContext(dispatcher) {
+        if (status.isEmpty()) return@withContext 0L
+        return@withContext database.connection.use { connection ->
+            val placeholders = status.joinToString(", ") { "?" }
+            connection
+                .prepareStatement(
+                    """
+                        SELECT COUNT(*) AS total
+                        FROM nl_behov
+                        WHERE
+                            orgnummer = ?
+                        AND
+                            behov_status in ($placeholders)
+                        AND
+                            created > ?
+                    """.trimIndent()
+                ).use { preparedStatement ->
+                    var idx = 1
+                    preparedStatement.setString(idx++, orgNumber)
+                    status.forEach { status ->
+                        preparedStatement.setObject(idx++, status, java.sql.Types.OTHER)
+                    }
+                    preparedStatement.setTimestamp(idx, Timestamp.from(createdAfter))
+                    preparedStatement.executeQuery().use { resultSet ->
+                        if (resultSet.next()) resultSet.getLong("total") else 0L
+                    }
                 }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementCollection.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementCollection.kt
@@ -6,14 +6,15 @@ class LinemanagerRequirementCollection(
 ) {
     companion object {
         const val DEFAULT_PAGE_SIZE = 50
-        fun from(list: List<LinemanagerRequirementRead>, pageSize: Int): LinemanagerRequirementCollection {
+        fun from(list: List<LinemanagerRequirementRead>, pageSize: Int, total: Long): LinemanagerRequirementCollection {
             val hasMore = list.size > pageSize
             return LinemanagerRequirementCollection(
                 linemanagerRequirements = if (!hasMore) list else list.dropLast(1),
                 meta = PageInfo(
                     size = if (!hasMore) list.size else list.size - 1,
                     pageSize = pageSize,
-                    hasMore = hasMore
+                    hasMore = hasMore,
+                    total = total,
                 )
             )
         }
@@ -23,5 +24,6 @@ class LinemanagerRequirementCollection(
 class PageInfo(
     val size: Int,
     val pageSize: Int,
-    val hasMore: Boolean
+    val hasMore: Boolean,
+    val total: Long,
 )

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementCollection.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/domain/LinemanagerRequirementCollection.kt
@@ -6,15 +6,21 @@ class LinemanagerRequirementCollection(
 ) {
     companion object {
         const val DEFAULT_PAGE_SIZE = 50
-        fun from(list: List<LinemanagerRequirementRead>, pageSize: Int, total: Long): LinemanagerRequirementCollection {
+
+        fun from(list: List<LinemanagerRequirementRead>, pageSize: Int, total: Long? = null): LinemanagerRequirementCollection {
             val hasMore = list.size > pageSize
+            val returnedSize = if (!hasMore) list.size else list.size - 1
+
+            require(!hasMore || total != null) { "total must be provided when the page may have more results" }
+            val resolvedTotal = total ?: returnedSize.toLong()
+
             return LinemanagerRequirementCollection(
                 linemanagerRequirements = if (!hasMore) list else list.dropLast(1),
                 meta = PageInfo(
-                    size = if (!hasMore) list.size else list.size - 1,
+                    size = returnedSize,
                     pageSize = pageSize,
                     hasMore = hasMore,
-                    total = total,
+                    total = resolvedTotal,
                 )
             )
         }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/NarmestelederService.kt
@@ -228,6 +228,15 @@ class NarmestelederService(
         limit = pageSize + 1,
     ).map { it.toEmployeeLinemanagerRead(it.getName()) }
 
+    suspend fun countNlBehov(
+        orgNumber: OrganizationNumber,
+        createdAfter: Instant,
+    ): Long = nlDb.countBehovByParameters(
+        orgNumber = orgNumber.value,
+        createdAfter = createdAfter,
+        status = listOf(BehovStatus.BEHOV_CREATED, BehovStatus.DIALOGPORTEN_STATUS_SET_REQUIRES_ATTENTION),
+    )
+
     suspend fun updateStatusOnExpiredBehovs(validDaysAfterTom: Long) {
         var count: Int
         var totalUpdated = 0

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -631,7 +631,7 @@ components:
           description: Indicates if there are more results available beyond the current page.
           type: boolean
         total:
-          description: Total number of results matching the request filters. When the page probe does not find more than pageSize results, this is derived directly from the returned page because all matches are known. That includes both pages with fewer than pageSize items and pages with exactly pageSize items when no additional results exist. When additional results do exist (hasMore = true), it is resolved with an additional count so the value remains exact.
+          description: Total number of results matching the request filters.
           type: integer
           format: int64
       required:

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -620,7 +620,7 @@ components:
         - meta
 
     PageInfo:
-      description: Information about the pageSize and number of items in the result set.
+      description: Information about the page size, number of items in the current result set, and the total number of matches.
       type: object
       properties:
         size:
@@ -630,10 +630,15 @@ components:
         hasMore:
           description: Indicates if there are more results available beyond the current page.
           type: boolean
+        total:
+          description: Total number of results matching the request filters, independent of pageSize.
+          type: integer
+          format: int64
       required:
         - size
         - pageSize
         - hasMore
+        - total
     ErrorType:
       type: string
       description: |

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -631,7 +631,7 @@ components:
           description: Indicates if there are more results available beyond the current page.
           type: boolean
         total:
-          description: Total number of results matching the request filters, independent of pageSize.
+          description: Total number of results matching the request filters. When the page probe does not find more than pageSize results, this is derived directly from the returned page because all matches are known. That includes both pages with fewer than pageSize items and pages with exactly pageSize items when no additional results exist. When additional results do exist (hasMore = true), it is resolved with an additional count so the value remains exact.
           type: integer
           format: int64
       required:

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
@@ -1,11 +1,12 @@
 package no.nav.syfo.narmesteleder.api.v1
 
 import DefaultOrganization
-import createMockToken
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import createMockToken
+import defaultMocks
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -29,6 +30,10 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
+import linemanager
+import linemanagerRevoke
+import manager
+import nlBehovEntity
 import no.nav.syfo.API_V1_PATH
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.aareg.client.FakeAaregClient
@@ -74,14 +79,9 @@ import no.nav.syfo.pdl.client.FakePdlClient
 import no.nav.syfo.registerApiV1
 import no.nav.syfo.texas.MASKINPORTEN_NL_SCOPE
 import no.nav.syfo.texas.client.TexasHttpClient
+import prepareGetPersonResponse
 import java.time.Instant
 import java.util.UUID
-import defaultMocks
-import linemanager
-import linemanagerRevoke
-import manager
-import nlBehovEntity
-import prepareGetPersonResponse
 
 class LinenmanagerApiV1Test :
     DescribeSpec({
@@ -905,7 +905,7 @@ class LinenmanagerApiV1Test :
                 }
             }
             describe("GET /requirement") {
-                it("GET /requirement should use provided query parameters to fetch results") {
+                it("GET /requirement should skip count query when all results fit in the current page") {
                     withTestApplication {
                         texasHttpClientMock.defaultMocks(
                             systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:${narmesteLederRelasjon.orgNumber.value}"),
@@ -941,7 +941,7 @@ class LinenmanagerApiV1Test :
                                 limit = pageSize + 1, // +1 to check if there is more pages
                             )
                         }
-                        coVerify(exactly = 1) {
+                        coVerify(exactly = 0) {
                             fakeRepo.countBehovByParameters(
                                 orgNumber = requirement.orgNumber.value,
                                 createdAfter = any(),
@@ -954,7 +954,7 @@ class LinenmanagerApiV1Test :
                     }
                 }
 
-                it("GET /requirement should return total independently of current page size") {
+                it("GET /requirement should count total when the current page may have more results") {
                     withTestApplication {
                         texasHttpClientMock.defaultMocks(
                             systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:${narmesteLederRelasjon.orgNumber.value}"),
@@ -996,6 +996,17 @@ class LinenmanagerApiV1Test :
                         body.meta.pageSize shouldBe 1
                         body.meta.hasMore shouldBe true
                         body.meta.total shouldBe 2L
+
+                        coVerify(exactly = 1) {
+                            fakeRepo.countBehovByParameters(
+                                orgNumber = narmesteLederRelasjon.orgNumber.value,
+                                createdAfter = any(),
+                                status = listOf(
+                                    BehovStatus.BEHOV_CREATED,
+                                    BehovStatus.DIALOGPORTEN_STATUS_SET_REQUIRES_ATTENTION,
+                                ),
+                            )
+                        }
                     }
                 }
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
@@ -1,13 +1,13 @@
 package no.nav.syfo.narmesteleder.api.v1
 
 import DefaultOrganization
+import createMockToken
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import createMockToken
-import defaultMocks
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -29,9 +29,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
-import linemanager
-import linemanagerRevoke
-import manager
 import no.nav.syfo.API_V1_PATH
 import no.nav.syfo.aareg.AaregService
 import no.nav.syfo.aareg.client.FakeAaregClient
@@ -53,6 +50,7 @@ import no.nav.syfo.ereg.EregService
 import no.nav.syfo.ereg.client.FakeEregClient
 import no.nav.syfo.ereg.client.Organisasjon
 import no.nav.syfo.narmesteleder.db.FakeNarmestelederDb
+import no.nav.syfo.narmesteleder.db.NarmestelederBehovEntity
 import no.nav.syfo.narmesteleder.domain.BehovReason
 import no.nav.syfo.narmesteleder.domain.BehovStatus
 import no.nav.syfo.narmesteleder.domain.Linemanager
@@ -76,9 +74,14 @@ import no.nav.syfo.pdl.client.FakePdlClient
 import no.nav.syfo.registerApiV1
 import no.nav.syfo.texas.MASKINPORTEN_NL_SCOPE
 import no.nav.syfo.texas.client.TexasHttpClient
-import prepareGetPersonResponse
 import java.time.Instant
 import java.util.UUID
+import defaultMocks
+import linemanager
+import linemanagerRevoke
+import manager
+import nlBehovEntity
+import prepareGetPersonResponse
 
 class LinenmanagerApiV1Test :
     DescribeSpec({
@@ -923,6 +926,7 @@ class LinenmanagerApiV1Test :
                         val body = response.body<LinemanagerRequirementCollection>()
                         body.meta.pageSize shouldBe pageSize
                         body.meta.size shouldBe 1
+                        body.meta.total shouldBe 1L
                         body.linemanagerRequirements.first().id shouldBe requirementId
 
                         coVerify(exactly = 1) {
@@ -937,6 +941,61 @@ class LinenmanagerApiV1Test :
                                 limit = pageSize + 1, // +1 to check if there is more pages
                             )
                         }
+                        coVerify(exactly = 1) {
+                            fakeRepo.countBehovByParameters(
+                                orgNumber = requirement.orgNumber.value,
+                                createdAfter = any(),
+                                status = listOf(
+                                    BehovStatus.BEHOV_CREATED,
+                                    BehovStatus.DIALOGPORTEN_STATUS_SET_REQUIRES_ATTENTION,
+                                ),
+                            )
+                        }
+                    }
+                }
+
+                it("GET /requirement should return total independently of current page size") {
+                    withTestApplication {
+                        texasHttpClientMock.defaultMocks(
+                            systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:${narmesteLederRelasjon.orgNumber.value}"),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+                        val createdAfter = Instant.now().minusSeconds(60)
+                        suspend fun insertRequirement(entity: NarmestelederBehovEntity) {
+                            fakeRepo.insertNlBehov(entity)
+                        }
+                        insertRequirement(
+                            nlBehovEntity().copy(
+                                orgnummer = narmesteLederRelasjon.orgNumber.value,
+                                hovedenhetOrgnummer = narmesteLederRelasjon.orgNumber.value,
+                                behovStatus = BehovStatus.BEHOV_CREATED,
+                                fornavn = "Ansatt",
+                                etternavn = "En",
+                            )
+                        )
+                        insertRequirement(
+                            nlBehovEntity().copy(
+                                orgnummer = narmesteLederRelasjon.orgNumber.value,
+                                hovedenhetOrgnummer = narmesteLederRelasjon.orgNumber.value,
+                                behovStatus = BehovStatus.DIALOGPORTEN_STATUS_SET_REQUIRES_ATTENTION,
+                                fornavn = "Ansatt",
+                                etternavn = "To",
+                            )
+                        )
+
+                        val response = client.get(
+                            "$API_V1_PATH/$RECUIREMENT_PATH?orgNumber=${narmesteLederRelasjon.orgNumber.value}&createdAfter=$createdAfter&pageSize=1",
+                        ) {
+                            bearerAuth(createMockToken(narmesteLederRelasjon.orgNumber.value))
+                        }
+
+                        response.status shouldBe HttpStatusCode.OK
+                        val body = response.body<LinemanagerRequirementCollection>()
+                        body.linemanagerRequirements.shouldHaveSize(1)
+                        body.meta.size shouldBe 1
+                        body.meta.pageSize shouldBe 1
+                        body.meta.hasMore shouldBe true
+                        body.meta.total shouldBe 2L
                     }
                 }
 

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/db/FakeNarmestelederDb.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/db/FakeNarmestelederDb.kt
@@ -79,6 +79,17 @@ class FakeNarmestelederDb : INarmestelederDb {
             status.contains(it.behovStatus)
     }.take(limit)
 
+    override suspend fun countBehovByParameters(
+        orgNumber: String,
+        createdAfter: Instant,
+        status: List<BehovStatus>,
+    ): Long = store.values.count {
+        it.orgnummer == orgNumber &&
+            it.created.isAfter(createdAfter) &&
+            it.created.isBefore(Instant.now()) &&
+            status.contains(it.behovStatus)
+    }.toLong()
+
     override suspend fun getNlBehovByStatus(status: List<BehovStatus>, limit: Int): List<NarmestelederBehovEntity> = store.values.filter { it.behovStatus in status }
 
     fun lastId(): UUID? = order.lastOrNull()

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/db/NarmestelederDbTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/db/NarmestelederDbTest.kt
@@ -390,6 +390,55 @@ class NarmestelederDbTest :
                         NarmestelederBehovEntity::updated
                     )
                 }
+
+                it("should count all matching items independently of limit") {
+                    // Arrange
+                    val defaultSykmledteFnr = faker.numerify("###########")
+                    val defaultOrgnummer = faker.numerify("#########")
+                    val createdAfter = Instant.now().minusSeconds(3 * 60L)
+
+                    val nlBehovEntity1 = insertAndGetBehovWithId(
+                        nlBehovEntity().copy(
+                            sykmeldtFnr = defaultSykmledteFnr,
+                            orgnummer = defaultOrgnummer,
+                            behovStatus = BehovStatus.BEHOV_CREATED,
+                        )
+                    )!!
+                    val nlBehovEntity2 = insertAndGetBehovWithId(
+                        nlBehovEntity().copy(
+                            sykmeldtFnr = faker.numerify("###########"),
+                            orgnummer = defaultOrgnummer,
+                            behovStatus = BehovStatus.DIALOGPORTEN_STATUS_SET_REQUIRES_ATTENTION,
+                        )
+                    )!!
+                    insertAndGetBehovWithId(
+                        nlBehovEntity().copy(
+                            sykmeldtFnr = faker.numerify("###########"),
+                            orgnummer = defaultOrgnummer.reversed(),
+                            behovStatus = BehovStatus.BEHOV_CREATED,
+                        )
+                    )!!
+                    insertAndGetBehovWithId(
+                        nlBehovEntity().copy(
+                            sykmeldtFnr = faker.numerify("###########"),
+                            orgnummer = defaultOrgnummer,
+                            behovStatus = BehovStatus.BEHOV_FULFILLED,
+                        )
+                    )!!
+
+                    updateCreated(nlBehovEntity1.id!!, createdAfter.plusSeconds(1))
+                    updateCreated(nlBehovEntity2.id!!, createdAfter.plusSeconds(1))
+
+                    // Act
+                    val total = db.countBehovByParameters(
+                        orgNumber = defaultOrgnummer,
+                        createdAfter = createdAfter,
+                        status = listOf(BehovStatus.BEHOV_CREATED, BehovStatus.DIALOGPORTEN_STATUS_SET_REQUIRES_ATTENTION),
+                    )
+
+                    // Assert
+                    total shouldBe 2L
+                }
             }
         }
 


### PR DESCRIPTION
## Beskrivelse

Legger til `meta.total` i `GET /linemanager/requirement`
`total` beregnes uten ekstra count-query når den hentede siden viser at alle treff allerede er med i responsen. Hvis det finnes flere resultater enn `pageSize`, brukes fortsatt count-query slik at `total` er eksakt.

## Endringer

- Legger til `total` i `PageInfo`
- Oppdatert dokumentasjon
- Oppdatert tester for begge pagineringsgrenene

## Issue

Ingen issue

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering
`./gradlew --no-daemon clean build`