### PR TITLE
feat(nais): allow inbound access from min-side-arbeidsgiver

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -86,6 +86,8 @@ spec:
         - application: tokenx-token-generator
           namespace: nais
         - application: narmesteleder-frontend
+        - application: min-side-arbeidsgiver
+          namespace: fager
     outbound:
       rules:
         - application: dinesykmeldte-backend

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -78,6 +78,8 @@ spec:
     inbound:
       rules:
         - application: narmesteleder-frontend
+        - application: min-side-arbeidsgiver
+          namespace: fager
     outbound:
       rules:
         - application: dinesykmeldte-backend


### PR DESCRIPTION
Tillater inbound requester fra `min-side-arbeidsgiver`.