### PR TITLE
chore(java): bump to 25 LTS

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -23,4 +23,4 @@ jobs:
     secrets: inherit
     with:
       app: esyfo-narmesteleder
-      java-version: '21'
+      java-version: "25"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,6 @@
 [tools]
-java = { version = "21" }
+java = "25"
+
 [tasks.docker-up]
 description = "Spin up dependency services using Docker Compose. Postgres, Kafka etc."
 run = '''

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75 -Dlogback.configurationFile=logback.xml"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ application {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 val avroSchemasDir = "src/main/avro"


### PR DESCRIPTION
## Beskrivelse

Oppgraderer applikasjonen til Java 25 LTS på tvers av lokal utvikling, build og runtime, slik at versjonen er konsistent i hele kjeden.

## Endringer

- `build.gradle.kts`: oppdatert Kotlin JVM toolchain til 25
- `Dockerfile`: oppdatert runtime-image til `openjdk-25`
- `.github/workflows/build-and-deploy.yaml`: oppdatert CI-build til Java 25
- `.mise.toml`: oppdatert lokal Java-versjon til 25

## Issue

Closes #422

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)