### PR TITLE
fix(validation): reject invalid manager contact details

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt
@@ -1,7 +1,9 @@
 package no.nav.syfo.narmesteleder.service
 
 import no.nav.syfo.aareg.AaregService
+import no.nav.syfo.application.api.ErrorType
 import no.nav.syfo.application.auth.Principal
+import no.nav.syfo.application.exception.ApiErrorException
 import no.nav.syfo.narmesteleder.domain.ContactValidationIssue
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerActors
@@ -41,6 +43,12 @@ class ValidationService(
     ): Manager {
         val validation = manager.normalizeContactDetails()
         logContactValidationIssues(validation.issues, context)
+        if (validation.issues.isNotEmpty()) {
+            throw ApiErrorException.BadRequestException(
+                errorMessage = validation.issues.toBadRequestMessage(),
+                type = ErrorType.INVALID_FORMAT,
+            )
+        }
         return validation.manager
     }
 
@@ -106,7 +114,7 @@ class ValidationService(
     ) {
         issues.forEach { issue ->
             logger.warn(
-                "ContactValidationIssue: Received manager payload with invalid {} for {}. Keeping original value. Reason: {}",
+                "ContactValidationIssue: Received manager payload with invalid {} for {}. Rejecting request. Reason: {}",
                 issue.fieldName,
                 context,
                 issue.reason,
@@ -114,3 +122,8 @@ class ValidationService(
         }
     }
 }
+
+private fun List<ContactValidationIssue>.toBadRequestMessage(): String = joinToString(
+    prefix = "Invalid manager contact details: ",
+    separator = "; ",
+) { "${it.fieldName}: ${it.reason}" }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt
@@ -266,7 +266,7 @@ class LinenmanagerApiV1Test :
                     }
                 }
 
-                it("Maskinporten POST /linemanager should accept invalid phone and email without rejecting payload") {
+                it("Maskinporten POST /linemanager should return 400 for invalid phone and email") {
                     withTestApplication {
                         val linemanagerWithInvalidContacts = narmesteLederRelasjon.copy(
                             manager = narmesteLederRelasjon.manager.copy(
@@ -298,16 +298,14 @@ class LinenmanagerApiV1Test :
                                 bearerAuth(createMockToken(linemanagerWithInvalidContacts.orgNumber.value))
                             }
 
-                        response.status shouldBe HttpStatusCode.Accepted
-                        coVerify(exactly = 1) {
-                            narmestelederKafkaServiceSpy.sendNarmesteLederRelasjon(
-                                match {
-                                    it.manager.mobile == "90-00-00-00" &&
-                                        it.manager.email == "gyldig@example.com; invalid @example.com"
-                                },
-                                any(),
-                                NlResponseSource.LPS,
-                            )
+                        val apiError = response.body<ApiError>()
+                        response.status shouldBe HttpStatusCode.BadRequest
+                        apiError.type shouldBe ErrorType.INVALID_FORMAT
+                        apiError.message.contains("90-00-00-00") shouldBe false
+                        apiError.message.contains("invalid @example.com") shouldBe false
+                        apiError.message.contains("gyldig@example.com") shouldBe false
+                        coVerify(exactly = 0) {
+                            narmestelederKafkaServiceSpy.sendNarmesteLederRelasjon(any(), any(), any())
                         }
                     }
                 }
@@ -840,6 +838,40 @@ class LinenmanagerApiV1Test :
                                 any(),
                                 any(),
                             )
+                        }
+                    }
+                }
+
+                it("PUT /requirement/{id} should return 400 for invalid phone and email") {
+                    withTestApplication {
+                        texasHttpClientMock.defaultMocks(
+                            systemBrukerOrganisasjon = DefaultOrganization.copy(ID = "0192:$orgnummer"),
+                            scope = MASKINPORTEN_NL_SCOPE,
+                        )
+                        val requirementId = seedLinemanagerRequirement()
+                        val invalidContactManager = manager().copy(
+                            nationalIdentificationNumber = PersonalIdentificationNumber(
+                                narmesteLederRelasjon.manager.nationalIdentificationNumber.value.reversed(),
+                            ),
+                            mobile = "90-00-00-00",
+                            email = "gyldig@example.com; invalid @example.com",
+                        )
+
+                        val response =
+                            client.put("$API_V1_PATH/$RECUIREMENT_PATH/$requirementId") {
+                                contentType(ContentType.Application.Json)
+                                setBody(invalidContactManager)
+                                bearerAuth(createMockToken(orgnummer))
+                            }
+
+                        val apiError = response.body<ApiError>()
+                        response.status shouldBe HttpStatusCode.BadRequest
+                        apiError.type shouldBe ErrorType.INVALID_FORMAT
+                        apiError.message.contains("90-00-00-00") shouldBe false
+                        apiError.message.contains("invalid @example.com") shouldBe false
+                        apiError.message.contains("gyldig@example.com") shouldBe false
+                        coVerify(exactly = 0) {
+                            narmestelederKafkaServiceSpy.sendNarmesteLederRelasjon(any(), any(), any())
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt
@@ -170,7 +170,7 @@ class ValidationServiceTest :
                 warningMessages() shouldHaveSize 0
             }
 
-            it("should keep invalid manager contact details and log warnings without raw values") {
+            it("should reject invalid manager contact details and log warnings without raw values") {
                 val manager = Manager(
                     nationalIdentificationNumber = PersonalIdentificationNumber("12345678910"),
                     lastName = "Jensen",
@@ -178,35 +178,46 @@ class ValidationServiceTest :
                     email = "gyldig@example.com; invalid @example.com",
                 )
 
-                val normalized = service.normalizeManagerPayload(
-                    manager = manager,
-                    context = "operation=PUT /linemanager/requirement/{id}",
-                )
+                val exception = shouldThrow<ApiErrorException.BadRequestException> {
+                    service.normalizeManagerPayload(
+                        manager = manager,
+                        context = "operation=PUT /linemanager/requirement/{id}",
+                    )
+                }
 
-                normalized shouldBe manager
+                exception.type shouldBe ErrorType.INVALID_FORMAT
+                exception.message shouldBe
+                    "Invalid manager contact details: mobile: PhoneNumber must contain only digits, with an optional leading plus sign; email: EmailAddress must not contain whitespace"
                 warningMessages() shouldHaveSize 2
                 warningMessages().single { it.contains("invalid mobile") } shouldBe
-                    "ContactValidationIssue: Received manager payload with invalid mobile for operation=PUT /linemanager/requirement/{id}. Keeping original value. Reason: PhoneNumber must contain only digits, with an optional leading plus sign"
+                    "ContactValidationIssue: Received manager payload with invalid mobile for operation=PUT /linemanager/requirement/{id}. Rejecting request. Reason: PhoneNumber must contain only digits, with an optional leading plus sign"
                 warningMessages().single { it.contains("invalid email") } shouldBe
-                    "ContactValidationIssue: Received manager payload with invalid email for operation=PUT /linemanager/requirement/{id}. Keeping original value. Reason: EmailAddress must not contain whitespace"
+                    "ContactValidationIssue: Received manager payload with invalid email for operation=PUT /linemanager/requirement/{id}. Rejecting request. Reason: EmailAddress must not contain whitespace"
                 warningMessages().any { it.contains("90-00-00-00") } shouldBe false
                 warningMessages().any { it.contains("invalid @example.com") } shouldBe false
                 warningMessages().any { it.contains("gyldig@example.com") } shouldBe false
+                exception.message?.contains("90-00-00-00") shouldBe false
+                exception.message?.contains("invalid @example.com") shouldBe false
+                exception.message?.contains("gyldig@example.com") shouldBe false
             }
 
-            it("should keep phone numbers with misplaced plus sign and log warning") {
+            it("should reject phone numbers with misplaced plus sign and log warning") {
                 val manager = manager().copy(
                     mobile = "47+90000000",
                 )
 
-                val normalized = service.normalizeManagerPayload(
-                    manager = manager,
-                    context = "path=/api/v1/linemanager",
-                )
+                val exception = shouldThrow<ApiErrorException.BadRequestException> {
+                    service.normalizeManagerPayload(
+                        manager = manager,
+                        context = "path=/api/v1/linemanager",
+                    )
+                }
 
-                normalized.mobile shouldBe "47+90000000"
+                exception.type shouldBe ErrorType.INVALID_FORMAT
+                exception.message shouldBe
+                    "Invalid manager contact details: mobile: PhoneNumber must contain only digits, with an optional leading plus sign"
                 warningMessages().single() shouldBe
-                    "ContactValidationIssue: Received manager payload with invalid mobile for path=/api/v1/linemanager. Keeping original value. Reason: PhoneNumber must contain only digits, with an optional leading plus sign"
+                    "ContactValidationIssue: Received manager payload with invalid mobile for path=/api/v1/linemanager. Rejecting request. Reason: PhoneNumber must contain only digits, with an optional leading plus sign"
             }
         }
         describe("validateNarmesteleder") {


### PR DESCRIPTION
## Beskrivelse
Returnerer 400 Bad Request nar `manager.email` eller `manager.mobile` ikke passerer value class-valideringen, samtidig som valideringsfeilen fortsatt logges.

## Endringer
- `src/main/kotlin/no/nav/syfo/narmesteleder/service/ValidationService.kt`: avviser ugyldige kontaktdata med `ApiErrorException.BadRequestException` og `ErrorType.INVALID_FORMAT`, og beholder logging
- `src/test/kotlin/no/nav/syfo/narmesteleder/service/ValidationServiceTest.kt`: oppdaterer servicetester til a forvente 400-feil og ingen lekkasje av raverdier i meldingene
- `src/test/kotlin/no/nav/syfo/narmesteleder/api/v1/LinenmanagerApiV1Test.kt`: oppdaterer POST-test og legger til PUT-test som verifiserer 400-respons og at Kafka ikke kalles

## Issue
Closes #421

## Sjekkliste
- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)