### PR TITLE
fix: fjern PII fra shadow-logging

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dinesykmeldte/ShadowActiveSykmeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/dinesykmeldte/ShadowActiveSykmeldingService.kt
@@ -1,11 +1,10 @@
 package no.nav.syfo.dinesykmeldte
 
 import io.micrometer.core.instrument.Counter
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import no.nav.syfo.application.metric.METRICS_NS
 import no.nav.syfo.application.metric.METRICS_REGISTRY
 import no.nav.syfo.sykmelding.exposed.IActiveSykmeldingRepository
+import no.nav.syfo.sykmelding.exposed.LocalActiveSykmeldingResult
 import no.nav.syfo.util.logger
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -30,136 +29,85 @@ class ShadowActiveSykmeldingService(
     private val dinesykmeldteService: DinesykmeldteService,
     private val repository: IActiveSykmeldingRepository,
 ) : IDinesykmeldteService {
-    override suspend fun getIsActiveSykmelding(personIdent: String, orgnummer: String): Boolean = coroutineScope {
-        val clientResultDeferred = async {
-            suspendRunCatching {
-                dinesykmeldteService.getIsActiveSykmelding(personIdent, orgnummer)
-            }
+    override suspend fun getIsActiveSykmelding(personIdent: String, orgnummer: String): Boolean {
+        val clientResult = suspendRunCatching {
+            dinesykmeldteService.getIsActiveSykmelding(personIdent, orgnummer)
         }
-        val localResultDeferred = async {
-            suspendRunCatching {
-                repository.hasActiveSykmelding(personIdent, orgnummer)
-            }
-        }
-
-        val clientResult = clientResultDeferred.await()
-        val localResult = localResultDeferred.await()
-
         if (clientResult.isSuccess) {
-            return@coroutineScope handleSuccessfulClientResult(
+            val localResult = suspendRunCatching {
+                repository.findActiveSykmelding(personIdent, orgnummer)
+            }
+            return handleSuccessfulClientResult(
                 clientValue = clientResult.getOrThrow(),
                 localResult = localResult,
-                personIdent = personIdent,
-                orgnummer = orgnummer,
             )
         } else {
             handleFailedClientResult(
                 clientException = clientResult.exceptionOrNull() ?: error("Missing client exception"),
-                localResult = localResult,
-                personIdent = personIdent,
-                orgnummer = orgnummer,
             )
         }
     }
 
     private fun handleSuccessfulClientResult(
         clientValue: Boolean,
-        localResult: Result<Boolean>,
-        personIdent: String,
-        orgnummer: String,
+        localResult: Result<LocalActiveSykmeldingResult>,
     ): Boolean {
         localResult
-            .onSuccess { logMismatchIfAny(clientValue, localResult.getOrThrow(), personIdent, orgnummer) }
-            .onFailure { localException -> logLocalShadowQueryFailed(personIdent, orgnummer, localException) }
+            .onSuccess { localValue -> logMismatchIfAny(clientValue, localValue.isActive) }
+            .onFailure { localException -> logLocalShadowQueryFailed(localException) }
         return clientValue
     }
 
     private fun handleFailedClientResult(
         clientException: Throwable,
-        localResult: Result<Boolean>,
-        personIdent: String,
-        orgnummer: String,
-    ): Boolean {
-        logClientFailedUsingLocalFallback(
-            personIdent = personIdent,
-            orgnummer = orgnummer,
+    ): Nothing {
+        logClientFailedRethrowingClientException(
             clientException = clientException,
         )
-
-        return localResult.getOrElse { localException ->
-            logLocalShadowQueryAlsoFailed(
-                personIdent = personIdent,
-                orgnummer = orgnummer,
-                localException = localException,
-            )
-            throw clientException
-        }
+        throw clientException
     }
 
     private fun logMismatchIfAny(
         clientValue: Boolean,
         localValue: Boolean,
-        personIdent: String,
-        orgnummer: String,
     ) {
         if (clientValue != localValue) {
-            countMismatch(clientValue, localValue).increment()
+            val direction = directionOf(clientValue, localValue)
+            countMismatch(direction).increment()
             logger.warn(
-                "Shadow mismatch for active sykmelding for fnr={} and orgnummer={}: client={}, local={}",
-                maskFnr(personIdent),
-                orgnummer,
+                "Shadow mismatch for active sykmelding: direction={}, client={}, local={}",
+                direction,
                 clientValue,
                 localValue,
             )
         }
     }
 
-    private fun logLocalShadowQueryFailed(
-        personIdent: String,
-        orgnummer: String,
-        localException: Throwable,
-    ) {
+    private fun logLocalShadowQueryFailed(localException: Throwable) {
         logger.warn(
-            "Local shadow query failed for fnr={} and orgnummer={}, ignoring local result. Exception type={}",
-            maskFnr(personIdent),
-            orgnummer,
+            "Local shadow query failed, ignoring local result. Exception type={}",
             localException::class.simpleName ?: "UnknownException",
         )
     }
 
-    private fun logClientFailedUsingLocalFallback(
-        personIdent: String,
-        orgnummer: String,
-        clientException: Throwable,
-    ) {
+    private fun logClientFailedRethrowingClientException(clientException: Throwable) {
         logger.warn(
-            "Dinesykmeldte client failed for fnr={} and orgnummer={}, using local fallback. Exception type={}",
-            maskFnr(personIdent),
-            orgnummer,
+            "Dinesykmeldte client failed, rethrowing client exception. Exception type={}",
             clientException::class.simpleName ?: "UnknownException",
         )
     }
 
-    private fun logLocalShadowQueryAlsoFailed(
-        personIdent: String,
-        orgnummer: String,
-        localException: Throwable,
-    ) {
-        logger.warn(
-            "Local shadow query also failed for fnr={} and orgnummer={}, rethrowing client exception. Exception type={}",
-            maskFnr(personIdent),
-            orgnummer,
-            localException::class.simpleName ?: "UnknownException",
-        )
-    }
-
-    private fun countMismatch(clientValue: Boolean, localValue: Boolean): Counter = when {
-        clientValue && !localValue -> COUNT_ACTIVE_SYKMELDING_SHADOW_MISMATCH_CLIENT_TRUE_LOCAL_FALSE
-        !clientValue && localValue -> COUNT_ACTIVE_SYKMELDING_SHADOW_MISMATCH_CLIENT_FALSE_LOCAL_TRUE
+    private fun directionOf(clientValue: Boolean, localValue: Boolean): String = when {
+        clientValue && !localValue -> SHADOW_DIRECTION_CLIENT_TRUE_LOCAL_FALSE
+        !clientValue && localValue -> SHADOW_DIRECTION_CLIENT_FALSE_LOCAL_TRUE
         else -> error("Unexpected shadow mismatch combination")
     }
 
-    private fun maskFnr(personIdent: String): String = "****${personIdent.takeLast(4)}"
+    private fun countMismatch(direction: String): Counter = when (direction) {
+        SHADOW_DIRECTION_CLIENT_TRUE_LOCAL_FALSE -> COUNT_ACTIVE_SYKMELDING_SHADOW_MISMATCH_CLIENT_TRUE_LOCAL_FALSE
+        SHADOW_DIRECTION_CLIENT_FALSE_LOCAL_TRUE -> COUNT_ACTIVE_SYKMELDING_SHADOW_MISMATCH_CLIENT_FALSE_LOCAL_TRUE
+        else -> error("Unexpected shadow mismatch direction")
+    }
 
     private inline fun <T> suspendRunCatching(block: () -> T): Result<T> = try {
         Result.success(block())

--- a/src/main/kotlin/no/nav/syfo/sykmelding/exposed/SendtSykmeldingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/exposed/SendtSykmeldingRepository.kt
@@ -7,13 +7,22 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greaterEq
 import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import java.time.Clock
 import java.time.LocalDate
+import java.util.UUID
 
 interface IActiveSykmeldingRepository {
-    suspend fun hasActiveSykmelding(fnr: String, orgnummer: String): Boolean
+    suspend fun findActiveSykmelding(fnr: String, orgnummer: String): LocalActiveSykmeldingResult
+}
+
+class LocalActiveSykmeldingResult(
+    val isActive: Boolean,
+    /** Internal value for controlled troubleshooting; must never be logged or used as a standard log correlation ID. */
+    val sykmeldingId: UUID?,
+) {
+    override fun toString(): String = "LocalActiveSykmeldingResult(isActive=$isActive, sykmeldingId=<redacted>)"
 }
 
 class SendtSykmeldingRepository(
@@ -21,12 +30,13 @@ class SendtSykmeldingRepository(
     private val clock: Clock = Clock.systemDefaultZone(),
 ) : IActiveSykmeldingRepository {
 
-    override suspend fun hasActiveSykmelding(fnr: String, orgnummer: String): Boolean {
+    override suspend fun findActiveSykmelding(fnr: String, orgnummer: String): LocalActiveSykmeldingResult {
         val activeTomThreshold = LocalDate.now(clock).minusDays(ACTIVE_SYKMELDING_GRACE_PERIOD_DAYS)
 
         return withContext(Dispatchers.IO) {
             suspendTransaction(db = database) {
-                SendtSykmeldingTable.selectAll()
+                val row = SendtSykmeldingTable
+                    .select(SendtSykmeldingTable.sykmeldingId)
                     .where {
                         (SendtSykmeldingTable.fnr eq fnr) and
                             (SendtSykmeldingTable.orgnummer eq orgnummer) and
@@ -34,7 +44,12 @@ class SendtSykmeldingRepository(
                             (SendtSykmeldingTable.tom greaterEq activeTomThreshold)
                     }
                     .limit(1)
-                    .any()
+                    .firstOrNull()
+
+                LocalActiveSykmeldingResult(
+                    isActive = row != null,
+                    sykmeldingId = row?.get(SendtSykmeldingTable.sykmeldingId),
+                )
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/dinesykmeldte/ShadowActiveSykmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dinesykmeldte/ShadowActiveSykmeldingServiceTest.kt
@@ -111,7 +111,6 @@ class ShadowActiveSykmeldingServiceTest :
 
             exception shouldBe clientException
             coVerify(exactly = 0) { repository.findActiveSykmelding(any(), any()) }
-            warningMessages() shouldHaveSize 1
             warningMessages().single() shouldBe
                 "Dinesykmeldte client failed, rethrowing client exception. Exception type=RuntimeException"
             warningArguments() shouldBe listOf("RuntimeException")

--- a/src/test/kotlin/no/nav/syfo/dinesykmeldte/ShadowActiveSykmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dinesykmeldte/ShadowActiveSykmeldingServiceTest.kt
@@ -10,8 +10,11 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import no.nav.syfo.sykmelding.exposed.IActiveSykmeldingRepository
+import no.nav.syfo.sykmelding.exposed.LocalActiveSykmeldingResult
 import org.slf4j.LoggerFactory
+import java.util.UUID
 import kotlin.coroutines.cancellation.CancellationException
 
 class ShadowActiveSykmeldingServiceTest :
@@ -23,7 +26,9 @@ class ShadowActiveSykmeldingServiceTest :
         val logAppender = ListAppender<ILoggingEvent>()
         val originalLevel = logbackLogger.level
         val fnr = "12345678910"
-        val orgnummer = "123456789"
+        val orgnummer = "998877665"
+        val maskedFnr = "****${fnr.takeLast(4)}"
+        val localSykmeldingId = UUID.fromString("11111111-1111-1111-1111-111111111111")
 
         beforeSpec {
             logbackLogger.level = Level.WARN
@@ -44,10 +49,19 @@ class ShadowActiveSykmeldingServiceTest :
 
         fun warningMessages(): List<String> = logAppender.list.map { it.formattedMessage }
         fun warningEvents(): List<ILoggingEvent> = logAppender.list.toList()
+        fun warningArguments(): List<Any?> = logAppender.list.flatMap { it.argumentArray?.toList() ?: emptyList() }
+        fun localResult(isActive: Boolean, sykmeldingId: UUID? = null): LocalActiveSykmeldingResult = LocalActiveSykmeldingResult(isActive = isActive, sykmeldingId = sykmeldingId)
+        fun assertSensitiveValueNotLogged(value: String) {
+            warningMessages().any { it.contains(value) } shouldBe false
+            warningArguments().map { it?.toString().orEmpty() }.any { it.contains(value) } shouldBe false
+        }
+        fun assertNoSensitiveValuesLogged() {
+            listOf(fnr, orgnummer, maskedFnr, localSykmeldingId.toString()).forEach(::assertSensitiveValueNotLogged)
+        }
 
         it("returns client result and logs no warning when shadow matches") {
             coEvery { dinesykmeldteService.getIsActiveSykmelding(fnr, orgnummer) } returns true
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } returns true
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } returns localResult(isActive = true, sykmeldingId = localSykmeldingId)
 
             service.getIsActiveSykmelding(fnr, orgnummer) shouldBe true
             warningMessages() shouldHaveSize 0
@@ -55,66 +69,86 @@ class ShadowActiveSykmeldingServiceTest :
 
         it("returns client result and logs warning when client=true and local=false") {
             coEvery { dinesykmeldteService.getIsActiveSykmelding(fnr, orgnummer) } returns true
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } returns false
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } returns localResult(isActive = false)
 
             service.getIsActiveSykmelding(fnr, orgnummer) shouldBe true
 
             warningMessages() shouldHaveSize 1
             warningMessages().single() shouldBe
-                "Shadow mismatch for active sykmelding for fnr=****8910 and orgnummer=123456789: client=true, local=false"
+                "Shadow mismatch for active sykmelding: direction=client_true_local_false, client=true, local=false"
+            warningArguments() shouldBe listOf("client_true_local_false", true, false)
+            warningEvents().single().throwableProxy shouldBe null
+            assertNoSensitiveValuesLogged()
         }
 
         it("returns client result and logs warning when client=false and local=true") {
             coEvery { dinesykmeldteService.getIsActiveSykmelding(fnr, orgnummer) } returns false
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } returns true
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } returns localResult(isActive = true, sykmeldingId = localSykmeldingId)
 
             service.getIsActiveSykmelding(fnr, orgnummer) shouldBe false
 
             warningMessages() shouldHaveSize 1
             warningMessages().single() shouldBe
-                "Shadow mismatch for active sykmelding for fnr=****8910 and orgnummer=123456789: client=false, local=true"
+                "Shadow mismatch for active sykmelding: direction=client_false_local_true, client=false, local=true"
+            warningArguments() shouldBe listOf("client_false_local_true", false, true)
+            warningEvents().single().throwableProxy shouldBe null
+            assertNoSensitiveValuesLogged()
         }
 
-        it("falls back to local query when client fails") {
+        it("rethrows the original client exception when client fails even if local succeeds") {
+            val clientException = RuntimeException("client failed")
             coEvery {
                 dinesykmeldteService.getIsActiveSykmelding(
                     fnr,
                     orgnummer
                 )
-            } throws RuntimeException("client failed")
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } returns true
-
-            service.getIsActiveSykmelding(fnr, orgnummer) shouldBe true
-
-            warningMessages() shouldHaveSize 1
-            warningMessages().single() shouldBe
-                "Dinesykmeldte client failed for fnr=****8910 and orgnummer=123456789, using local fallback. Exception type=RuntimeException"
-            warningEvents().single().throwableProxy shouldBe null
-        }
-
-        it("rethrows the original client exception when both calls fail") {
-            val clientException = RuntimeException("client failed")
-            coEvery { dinesykmeldteService.getIsActiveSykmelding(fnr, orgnummer) } throws clientException
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } throws RuntimeException("local failed")
+            } throws clientException
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } returns localResult(isActive = true, sykmeldingId = localSykmeldingId)
 
             val exception = shouldThrow<RuntimeException> {
                 service.getIsActiveSykmelding(fnr, orgnummer)
             }
 
             exception shouldBe clientException
-            warningMessages() shouldHaveSize 2
+            coVerify(exactly = 0) { repository.findActiveSykmelding(any(), any()) }
+            warningMessages() shouldHaveSize 1
+            warningMessages().single() shouldBe
+                "Dinesykmeldte client failed, rethrowing client exception. Exception type=RuntimeException"
+            warningArguments() shouldBe listOf("RuntimeException")
+            warningEvents().single().throwableProxy shouldBe null
+            assertNoSensitiveValuesLogged()
+        }
+
+        it("rethrows the original client exception when both calls fail") {
+            val clientException = RuntimeException("client failed")
+            coEvery { dinesykmeldteService.getIsActiveSykmelding(fnr, orgnummer) } throws clientException
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } throws RuntimeException("local failed")
+
+            val exception = shouldThrow<RuntimeException> {
+                service.getIsActiveSykmelding(fnr, orgnummer)
+            }
+
+            exception shouldBe clientException
+            warningMessages() shouldHaveSize 1
+            warningMessages().single() shouldBe
+                "Dinesykmeldte client failed, rethrowing client exception. Exception type=RuntimeException"
+            warningArguments() shouldBe listOf("RuntimeException")
+            warningEvents().single().throwableProxy shouldBe null
+            assertNoSensitiveValuesLogged()
         }
 
         it("uses client result when only local query fails") {
             coEvery { dinesykmeldteService.getIsActiveSykmelding(fnr, orgnummer) } returns true
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } throws RuntimeException("local failed")
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } throws RuntimeException("local failed")
 
             service.getIsActiveSykmelding(fnr, orgnummer) shouldBe true
 
             warningMessages() shouldHaveSize 1
             warningMessages().single() shouldBe
-                "Local shadow query failed for fnr=****8910 and orgnummer=123456789, ignoring local result. Exception type=RuntimeException"
+                "Local shadow query failed, ignoring local result. Exception type=RuntimeException"
+            warningArguments() shouldBe listOf("RuntimeException")
             warningEvents().single().throwableProxy shouldBe null
+            assertNoSensitiveValuesLogged()
         }
 
         it("propagates cancellation exception from client call") {
@@ -124,7 +158,7 @@ class ShadowActiveSykmeldingServiceTest :
                     orgnummer
                 )
             } throws CancellationException("cancelled")
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } returns true
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } returns localResult(isActive = true, sykmeldingId = localSykmeldingId)
 
             shouldThrow<CancellationException> {
                 service.getIsActiveSykmelding(fnr, orgnummer)
@@ -133,7 +167,7 @@ class ShadowActiveSykmeldingServiceTest :
 
         it("propagates cancellation exception from local call") {
             coEvery { dinesykmeldteService.getIsActiveSykmelding(fnr, orgnummer) } returns true
-            coEvery { repository.hasActiveSykmelding(fnr, orgnummer) } throws CancellationException("cancelled")
+            coEvery { repository.findActiveSykmelding(fnr, orgnummer) } throws CancellationException("cancelled")
 
             shouldThrow<CancellationException> {
                 service.getIsActiveSykmelding(fnr, orgnummer)

--- a/src/test/kotlin/no/nav/syfo/sykmelding/exposed/SendtSykmeldingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/exposed/SendtSykmeldingRepositoryTest.kt
@@ -2,6 +2,8 @@ package no.nav.syfo.sykmelding.exposed
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import no.nav.syfo.TestDB
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -26,10 +28,11 @@ class SendtSykmeldingRepositoryTest :
             orgnummer: String = "123456789",
             tom: LocalDate,
             revokedDate: LocalDate? = null,
-        ) {
+        ): UUID {
+            val sykmeldingId = UUID.randomUUID()
             transaction(TestDB.exposedDatabase) {
                 SendtSykmeldingTable.insert {
-                    it[sykmeldingId] = UUID.randomUUID()
+                    it[SendtSykmeldingTable.sykmeldingId] = sykmeldingId
                     it[SendtSykmeldingTable.orgnummer] = orgnummer
                     it[syketilfelleStartDato] = tom.minusDays(10)
                     it[SendtSykmeldingTable.fnr] = fnr
@@ -38,38 +41,86 @@ class SendtSykmeldingRepositoryTest :
                     it[SendtSykmeldingTable.revokedDate] = revokedDate
                 }
             }
+            return sykmeldingId
         }
 
-        describe("hasActiveSykmelding") {
-            it("returns true when tom is on the included grace boundary") {
-                insertSendtSykmelding(tom = today.minusDays(SendtSykmeldingRepository.ACTIVE_SYKMELDING_GRACE_PERIOD_DAYS))
+        describe("LocalActiveSykmeldingResult.toString") {
+            it("redacts sykmeldingId in string output") {
+                val sykmeldingId = UUID.fromString("11111111-1111-1111-1111-111111111111")
 
-                repository.hasActiveSykmelding("12345678910", "123456789") shouldBe true
+                val result = LocalActiveSykmeldingResult(isActive = true, sykmeldingId = sykmeldingId)
+
+                result.toString() shouldBe
+                    "LocalActiveSykmeldingResult(isActive=true, sykmeldingId=<redacted>)"
+                result.toString() shouldNotContain sykmeldingId.toString()
+                result.toString() shouldContain "sykmeldingId=<redacted>"
+            }
+        }
+
+        describe("findActiveSykmelding") {
+            it("returns active result with sykmeldingId when tom is on the included grace boundary") {
+                val sykmeldingId =
+                    insertSendtSykmelding(tom = today.minusDays(SendtSykmeldingRepository.ACTIVE_SYKMELDING_GRACE_PERIOD_DAYS))
+
+                val result = repository.findActiveSykmelding("12345678910", "123456789")
+
+                result.isActive shouldBe true
+                result.sykmeldingId shouldBe sykmeldingId
             }
 
-            it("returns false when tom is outside the grace period") {
+            it("returns inactive result without sykmeldingId when tom is outside the grace period") {
                 insertSendtSykmelding(tom = today.minusDays(SendtSykmeldingRepository.ACTIVE_SYKMELDING_GRACE_PERIOD_DAYS + 1))
 
-                repository.hasActiveSykmelding("12345678910", "123456789") shouldBe false
+                val result = repository.findActiveSykmelding("12345678910", "123456789")
+
+                result.isActive shouldBe false
+                result.sykmeldingId shouldBe null
             }
 
-            it("returns false when sykmeldingen is revoked") {
+            it("returns inactive result without sykmeldingId when sykmeldingen is revoked") {
                 insertSendtSykmelding(
                     tom = today,
                     revokedDate = today.minusDays(1),
                 )
 
-                repository.hasActiveSykmelding("12345678910", "123456789") shouldBe false
+                val result = repository.findActiveSykmelding("12345678910", "123456789")
+
+                result.isActive shouldBe false
+                result.sykmeldingId shouldBe null
             }
 
-            it("returns false when there is no matching row") {
-                repository.hasActiveSykmelding("12345678910", "123456789") shouldBe false
+            it("returns inactive result without sykmeldingId when there is no matching row") {
+                val result = repository.findActiveSykmelding("12345678910", "123456789")
+
+                result.isActive shouldBe false
+                result.sykmeldingId shouldBe null
             }
 
-            it("returns true when tom is in the future") {
-                insertSendtSykmelding(tom = today.plusDays(5))
+            it("returns inactive result without sykmeldingId when fnr does not match an active row") {
+                insertSendtSykmelding(fnr = "10987654321", tom = today)
 
-                repository.hasActiveSykmelding("12345678910", "123456789") shouldBe true
+                val result = repository.findActiveSykmelding("12345678910", "123456789")
+
+                result.isActive shouldBe false
+                result.sykmeldingId shouldBe null
+            }
+
+            it("returns inactive result without sykmeldingId when orgnummer does not match an active row") {
+                insertSendtSykmelding(orgnummer = "987654321", tom = today)
+
+                val result = repository.findActiveSykmelding("12345678910", "123456789")
+
+                result.isActive shouldBe false
+                result.sykmeldingId shouldBe null
+            }
+
+            it("returns active result with sykmeldingId when tom is in the future") {
+                val sykmeldingId = insertSendtSykmelding(tom = today.plusDays(5))
+
+                val result = repository.findActiveSykmelding("12345678910", "123456789")
+
+                result.isActive shouldBe true
+                result.sykmeldingId shouldBe sykmeldingId
             }
         }
     })


### PR DESCRIPTION
## Beskrivelse

Fjerner PII fra shadow active sykmelding-logging og endrer client-feil-stien slik at lokal shadow-verdi ikke brukes som fallback.

## Endringer

- `ShadowActiveSykmeldingService`: logger ikke fnr, maskert fnr, orgnummer eller sykmeldingId i shadow-/feillogger
- `ShadowActiveSykmeldingService`: ved client-feil kastes original exception uten at lokalt oppslag startes
- `SendtSykmeldingRepository`: returnerer lokal shadow-resultatmodell med `sykmeldingId`, men redakterer ID-en i `toString()`
- Tester: verifiserer PII-frie loggmeldinger/argumenter, ingen local-kall ved client-feil og repository-resultat for sykmeldingId

## Issue

Closes #427

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Verifisert med `./gradlew --no-daemon clean build`.

R4-inspeksjon er gjennomført; funn om at local kunne starte før client-feil ble utbedret før PR.
