### PR TITLE
feat(narmesteleder): add fuzzy name matching metrics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ buildscript {
 dependencies {
     implementation(platform(libs.netty))
     implementation(libs.apache.avro)
+    implementation(libs.commons.text)
     implementation(libs.confluent.kafka.avro.serializer) {
         exclude(group = "org.apache.kafka", module = "kafka-clients")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 avro = "1.12.1"
+commons-text = "1.13.1"
 confluent = "8.1.1"
 datafaker = "2.7.0"
 flyway = "13.1.0"
@@ -28,6 +29,7 @@ netty = "4.2.16.Final"
 [libraries]
 apache-avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 apache-avro-tools = { module = "org.apache.avro:avro-tools", version.ref = "avro" }
+commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
 confluent-kafka-avro-serializer = { module = "io.confluent:kafka-avro-serializer", version.ref = "confluent" }
 database-flyway-core = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 database-hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/service/validators/NameValidator.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/service/validators/NameValidator.kt
@@ -1,12 +1,16 @@
 package no.nav.syfo.narmesteleder.service.validators
 
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
 import no.nav.syfo.application.api.ErrorType
 import no.nav.syfo.application.metric.METRICS_NS
 import no.nav.syfo.application.metric.METRICS_REGISTRY
 import no.nav.syfo.narmesteleder.domain.Linemanager
 import no.nav.syfo.narmesteleder.domain.LinemanagerRevoke
 import no.nav.syfo.pdl.Person
+import org.apache.commons.text.similarity.JaroWinklerSimilarity
+import java.text.Normalizer
+import java.util.concurrent.ConcurrentHashMap
 
 private const val PARALLEL_NAMES_VALIDATION_TOTAL =
     "${METRICS_NS}_parallel_names_validation_total"
@@ -16,6 +20,19 @@ private const val RESULT_TAG = "result"
 private const val RESULT_ATTEMPTED = "attempted"
 private const val RESULT_SUCCESS = "success"
 private const val RESULT_FAILED = "failed"
+private const val NAME_VALIDATION_TOTAL = "${METRICS_NS}_name_validation_total"
+private const val NAME_VALIDATION_DESCRIPTION = "Counts last name validation outcomes."
+private const val FUZZY_SCORE = "${METRICS_NS}_name_validation_fuzzy_score"
+private const val FUZZY_SCORE_DESCRIPTION = "Jaro-Winkler scores after an exact last name match fails."
+private const val MATCH_TYPE_TAG = "match_type"
+private const val NAME_SOURCE_TAG = "name_source"
+private const val VALIDATION_RESULT_TAG = "validation_result"
+private const val NAME_SOURCE_SINGLE = "single"
+private const val NAME_SOURCE_PARALLEL = "parallel"
+private const val VALIDATION_RESULT_ACCEPTED = "accepted"
+private const val VALIDATION_RESULT_REJECTED = "rejected"
+private const val FUZZY_MATCH_THRESHOLD = 0.93
+private const val MINIMUM_FUZZY_MATCH_LETTERS = 4
 
 private const val EMPLOYEE_NAME_VALIDATION_FAILED_MESSAGE =
     "Last name for employee on sick leave does not correspond with registered value for the given national identification number"
@@ -23,6 +40,7 @@ private const val LINEMANAGER_NAME_VALIDATION_FAILED_MESSAGE =
     "Last name for linemanager does not correspond with registered value for the given national identification number"
 
 object NameValidator {
+    private val jaroWinklerSimilarity = JaroWinklerSimilarity()
     private val parallelNamesValidationCounters: Map<String, Counter> = listOf(
         RESULT_ATTEMPTED,
         RESULT_SUCCESS,
@@ -33,6 +51,8 @@ object NameValidator {
             .tag(RESULT_TAG, result)
             .register(METRICS_REGISTRY)
     }
+    private val nameValidationCounters = ConcurrentHashMap<NameValidationMetricKey, Counter>()
+    private val fuzzyScoreSummaries = ConcurrentHashMap<String, DistributionSummary>()
 
     fun validateLinemanagerLastName(
         managerPdlPerson: Person,
@@ -70,31 +90,120 @@ object NameValidator {
         }
     }
 
-    private fun validateLastName(nameToValidate: String, pdlPerson: Person): Boolean = if (pdlPerson.hasParallelNames) {
-        countParallelNamesValidation(result = RESULT_ATTEMPTED)
-        val matchesPdlNames = validateParallelNames(
-            nameToValidate.normalizeName(),
-            pdlPerson.names.map { it.etternavn.normalizeName() }
+    private fun validateLastName(nameToValidate: String, pdlPerson: Person): Boolean {
+        val nameSource = if (pdlPerson.hasParallelNames) NAME_SOURCE_PARALLEL else NAME_SOURCE_SINGLE
+        val matchType = determineMatchType(
+            nameToValidate = nameToValidate,
+            pdlLastNames = pdlPerson.names.map { it.etternavn },
+            nameSource = nameSource,
         )
+        val isAccepted = matchType == NameMatchType.EXACT
 
-        if (matchesPdlNames) {
-            countParallelNamesValidation(result = RESULT_SUCCESS)
-        } else {
-            countParallelNamesValidation(result = RESULT_FAILED)
+        countNameValidation(matchType, nameSource, isAccepted)
+        if (pdlPerson.hasParallelNames) {
+            countParallelNamesValidation(result = RESULT_ATTEMPTED)
+            countParallelNamesValidation(
+                result = if (isAccepted) RESULT_SUCCESS else RESULT_FAILED,
+            )
         }
 
-        matchesPdlNames
-    } else {
-        nameToValidate.normalizeName() == pdlPerson.name.etternavn.normalizeName()
+        return isAccepted
     }
 
-    private fun String.normalizeName() = this.trim().uppercase().replace("\\s+".toRegex(), " ")
+    internal fun determineMatchType(
+        nameToValidate: String,
+        pdlLastNames: List<String>,
+        nameSource: String,
+    ): NameMatchType {
+        val normalizedName = nameToValidate.normalizeName()
+        val normalizedPdlNames = pdlLastNames.map { it.normalizeName() }
+        if (normalizedPdlNames.any { it == normalizedName }) {
+            return NameMatchType.EXACT
+        }
 
-    // Under visse omstendigheter kan det forekomme at personer har parallelle navn i PDL
-    // https://pdl-docs.ansatt.nav.no/ekstern/index.html#_navn
-    private fun validateParallelNames(nameToValidate: String, parallelNames: List<String>): Boolean = parallelNames.any { it.equals(nameToValidate, ignoreCase = true) }
+        val fuzzyScores = normalizedPdlNames.mapNotNull { pdlName ->
+            fuzzyScore(normalizedName, pdlName)
+        }
+        fuzzyScores.maxOrNull()?.let { score ->
+            countFuzzyScore(nameSource, score)
+            if (passesFuzzyThreshold(score)) {
+                return NameMatchType.FUZZY
+            }
+        }
+
+        return NameMatchType.NONE
+    }
+
+    internal fun passesFuzzyThreshold(score: Double): Boolean = score >= FUZZY_MATCH_THRESHOLD
+
+    private fun String.normalizeName(): String = Normalizer.normalize(this, Normalizer.Form.NFC)
+        .trim()
+        .replace("\\s+".toRegex(), " ")
+        .replace(APOSTROPHE_VARIANTS.toRegex(), "'")
+        .replace(HYPHEN_VARIANTS.toRegex(), "-")
+        .uppercase()
+
+    private fun fuzzyScore(firstName: String, secondName: String): Double? = if (
+        firstName.isFuzzyEligible() &&
+        secondName.isFuzzyEligible()
+    ) {
+        jaroWinklerSimilarity.apply(firstName, secondName)
+    } else {
+        null
+    }
+
+    private fun String.isFuzzyEligible(): Boolean = letterCount() >= MINIMUM_FUZZY_MATCH_LETTERS &&
+        all { it.isLetter() || it.isWhitespace() || it == '\'' || it == '-' }
+
+    private fun String.letterCount(): Int = codePoints().filter(Character::isLetter).count().toInt()
 
     private fun countParallelNamesValidation(result: String) {
         parallelNamesValidationCounters.getValue(result).increment()
     }
+
+    private fun countNameValidation(
+        matchType: NameMatchType,
+        nameSource: String,
+        isAccepted: Boolean,
+    ) {
+        val key = NameValidationMetricKey(
+            matchType = matchType,
+            nameSource = nameSource,
+            validationResult = if (isAccepted) VALIDATION_RESULT_ACCEPTED else VALIDATION_RESULT_REJECTED,
+        )
+        nameValidationCounters.computeIfAbsent(key) {
+            Counter.builder(NAME_VALIDATION_TOTAL)
+                .description(NAME_VALIDATION_DESCRIPTION)
+                .tag(MATCH_TYPE_TAG, key.matchType.metricValue)
+                .tag(NAME_SOURCE_TAG, key.nameSource)
+                .tag(VALIDATION_RESULT_TAG, key.validationResult)
+                .register(METRICS_REGISTRY)
+        }.increment()
+    }
+
+    private fun countFuzzyScore(nameSource: String, score: Double) {
+        fuzzyScoreSummaries.computeIfAbsent(nameSource) {
+            DistributionSummary.builder(FUZZY_SCORE)
+                .description(FUZZY_SCORE_DESCRIPTION)
+                .tag(NAME_SOURCE_TAG, nameSource)
+                .register(METRICS_REGISTRY)
+        }.record(score)
+    }
+
+    private data class NameValidationMetricKey(
+        val matchType: NameMatchType,
+        val nameSource: String,
+        val validationResult: String,
+    )
+
+    private const val APOSTROPHE_VARIANTS = "[\u2018\u2019\u201B\uFF07]"
+    private const val HYPHEN_VARIANTS = "[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]"
+}
+
+internal enum class NameMatchType(
+    val metricValue: String,
+) {
+    EXACT("exact"),
+    FUZZY("fuzzy"),
+    NONE("none"),
 }

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/service/validators/NameValidatorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/service/validators/NameValidatorTest.kt
@@ -273,6 +273,91 @@ class NameValidatorTest :
                 parallelNamesValidationCount(result = RESULT_FAILED) shouldBeExactly failedBefore + 1.0
             }
         }
+
+        describe("name matching") {
+            it("normalizes Unicode, whitespace, apostrophes, and hyphens before exact matching") {
+                NameValidator.determineMatchType(
+                    nameToValidate = "  A\u030Astr\u00F6m\u2011O\u2019Connor  ",
+                    pdlLastNames = listOf("\u00C5str\u00F6m-O'Connor"),
+                    nameSource = NAME_SOURCE_SINGLE,
+                ) shouldBe NameMatchType.EXACT
+            }
+
+            it("does not remove unknown characters while normalizing") {
+                NameValidator.determineMatchType(
+                    nameToValidate = "O*Connor",
+                    pdlLastNames = listOf("OConnor"),
+                    nameSource = NAME_SOURCE_SINGLE,
+                ) shouldBe NameMatchType.NONE
+            }
+
+            it("only uses fuzzy matching when both names have at least four Unicode letters") {
+                NameValidator.determineMatchType(
+                    nameToValidate = "Aas",
+                    pdlLastNames = listOf("Aar"),
+                    nameSource = NAME_SOURCE_SINGLE,
+                ) shouldBe NameMatchType.NONE
+
+                NameValidator.determineMatchType(
+                    nameToValidate = "Hansen",
+                    pdlLastNames = listOf("Hanson"),
+                    nameSource = NAME_SOURCE_SINGLE,
+                ) shouldBe NameMatchType.FUZZY
+            }
+
+            it("uses an inclusive fuzzy matching threshold") {
+                NameValidator.passesFuzzyThreshold(0.93) shouldBe true
+                NameValidator.passesFuzzyThreshold(0.9301) shouldBe true
+                NameValidator.passesFuzzyThreshold(0.9299) shouldBe false
+            }
+
+            it("checks every parallel PDL name for an exact match before fuzzy matching") {
+                NameValidator.determineMatchType(
+                    nameToValidate = "Hansen",
+                    pdlLastNames = listOf("Hanson", "Hansen"),
+                    nameSource = NAME_SOURCE_PARALLEL,
+                ) shouldBe NameMatchType.EXACT
+            }
+
+            it("classifies a fuzzy match in a parallel PDL name") {
+                NameValidator.determineMatchType(
+                    nameToValidate = "Hansen",
+                    pdlLastNames = listOf("Haugland", "Hanson"),
+                    nameSource = NAME_SOURCE_PARALLEL,
+                ) shouldBe NameMatchType.FUZZY
+            }
+
+            it("does not classify clearly different names as fuzzy matches") {
+                NameValidator.determineMatchType(
+                    nameToValidate = "Hansen",
+                    pdlLastNames = listOf("Haugland"),
+                    nameSource = NAME_SOURCE_SINGLE,
+                ) shouldBe NameMatchType.NONE
+            }
+
+            it("records fuzzy candidates as rejected during the observation phase") {
+                val linemanager = linemanager().copy(lastName = "Hansen")
+                val employee = person(
+                    lastName = "Hanson",
+                    fnr = linemanager.employeeIdentificationNumber.value,
+                )
+                val before = nameValidationCount(
+                    matchType = "fuzzy",
+                    nameSource = NAME_SOURCE_SINGLE,
+                    validationResult = "rejected",
+                )
+
+                shouldThrow<ApiErrorException.BadRequestException> {
+                    NameValidator.validateEmployeeLastName(employee, linemanager)
+                }
+
+                nameValidationCount(
+                    matchType = "fuzzy",
+                    nameSource = NAME_SOURCE_SINGLE,
+                    validationResult = "rejected",
+                ) shouldBeExactly before + 1.0
+            }
+        }
     })
 
 private const val PARALLEL_NAMES_VALIDATION_TOTAL = "${METRICS_NS}_parallel_names_validation_total"
@@ -280,8 +365,30 @@ private const val RESULT_TAG = "result"
 private const val RESULT_ATTEMPTED = "attempted"
 private const val RESULT_SUCCESS = "success"
 private const val RESULT_FAILED = "failed"
+private const val NAME_VALIDATION_TOTAL = "${METRICS_NS}_name_validation_total"
+private const val MATCH_TYPE_TAG = "match_type"
+private const val NAME_SOURCE_TAG = "name_source"
+private const val VALIDATION_RESULT_TAG = "validation_result"
+private const val NAME_SOURCE_SINGLE = "single"
+private const val NAME_SOURCE_PARALLEL = "parallel"
 
 private fun parallelNamesValidationCount(result: String): Double = METRICS_REGISTRY.find(PARALLEL_NAMES_VALIDATION_TOTAL)
     .tag(RESULT_TAG, result)
+    .counter()
+    ?.count() ?: 0.0
+
+private fun nameValidationCount(
+    matchType: String,
+    nameSource: String,
+    validationResult: String,
+): Double = METRICS_REGISTRY.find(NAME_VALIDATION_TOTAL)
+    .tags(
+        MATCH_TYPE_TAG,
+        matchType,
+        NAME_SOURCE_TAG,
+        nameSource,
+        VALIDATION_RESULT_TAG,
+        validationResult,
+    )
     .counter()
     ?.count() ?: 0.0


### PR DESCRIPTION
## Beskrivelse

Legger til Jaro-Winkler-basert fuzzy-klassifisering for etternavn i observasjonsfase. Eksakte treff godkjennes som før, mens fuzzy-kandidater fortsatt avvises og måles før eventuell aktivering.

## Endringer

- `NameValidator`: Unicode-normalisering, fuzzy-klassifisering og sikkerhetsgrenser for tegn og navnelengde
- `NameValidator`: nye lavkardinalitetsmetrikker og score-histogram uten personopplysninger
- `gradle`: Apache Commons Text via version catalog
- `NameValidatorTest`: dekker normalisering, terskel, parallelle navn og observasjonsutfall

## Issue

Closes #458

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)